### PR TITLE
fix: note content width

### DIFF
--- a/assets/scss/partials/footer.scss
+++ b/assets/scss/partials/footer.scss
@@ -3,7 +3,7 @@ footer {
     margin: auto -5px 0px;
     clear: both;
     border-top: 1px solid var(--border-color-light);
-    background-color: var(--secondary-background-color-light);
+    background-color: var(--primary-background-color-light);
     z-index: 10;
     white-space: normal;
     font-size: 0.75rem;
@@ -35,7 +35,7 @@ footer span {
 html[data-theme=dark] {
     footer {
         border-top: 1px solid var(--border-color);
-        background-color: var(--secondary-background-color-var2);
+        background-color: var(--primary-background-color);
     }
 
     footer span {

--- a/assets/scss/partials/menu.scss
+++ b/assets/scss/partials/menu.scss
@@ -185,7 +185,7 @@ hr {
 }
 
 nav.menu {
-    background-color: var(--secondary-background-color-light);
+    background-color: var(--primary-background-color-light);
     display: inline-grid;
     grid-template-rows: 1fr min-content;
     grid-template-areas:
@@ -256,7 +256,7 @@ nav .site-nav ul li {
 html[data-theme=dark] {
     nav.menu {
         border-right: 1px solid var(--border-color);
-        background-color: var(--secondary-background-color-var2);
+        background-color: var(--primary-background-color);
     }
 
     hr {

--- a/assets/scss/partials/note-content.scss
+++ b/assets/scss/partials/note-content.scss
@@ -98,8 +98,9 @@ code.button {
         "nav content pagenav"
         "nav content pagenav";
     grid-template-rows: repeat(auto-fill, minmax(0px, 1fr));
-    grid-template-columns: 248px 1fr 248px;
+    grid-template-columns: 248px minmax(auto, var(--container-max-width)) 248px;
     column-gap: var(--column-gap);
+    justify-content: center;
     
     .pagenav {
         grid-area: pagenav;
@@ -140,6 +141,10 @@ html[data-reading-mode="true"] {
 
     .graph-container {
         display: none;
+    }
+
+    main {
+        font-size: 1.125rem;
     }
 }
 

--- a/assets/scss/variables.scss
+++ b/assets/scss/variables.scss
@@ -26,7 +26,7 @@
     --border-color: #3d3d3d;
     --border-color-light: #e7e7e7;
 
-    --container-max-width: 1240px;
+    --container-max-width: 770px;
     --main-padding: 24px 36px;
     --column-gap: 24px;
     --nav-sidebar-width: 200px;


### PR DESCRIPTION
#### What's this PR do?

- [ ] move body ra giữa page, ref brain.d.foundation (sidebar chắc sẽ phải đổi background, vẫn giữ border)
- [ ] content block giảm width (770px) so với hiện tại
- [ ] reading mode -> tăng font size của content block lên 1.125rem

#### Screenshots (if appropriate)

![image](https://github.com/dwarvesf/note.d.foundation/assets/44285614/77629c02-7204-4c06-8bfe-b41312786652)
![image](https://github.com/dwarvesf/note.d.foundation/assets/44285614/6e257783-465b-4d1f-ac36-a27a9ca0149b)

