### PR TITLE
perf(content): exclude content from list page data

### DIFF
--- a/src/lib/content/memo.ts
+++ b/src/lib/content/memo.ts
@@ -4,7 +4,15 @@ import { getAllMarkdownFiles, getContentPath } from './paths';
 import path from 'path';
 import { IMemoItem } from '@/types';
 
-export function getAllMarkdownContents(basePath = '') {
+interface GetAllMarkdownContentsOptions {
+  includeContent?: boolean;
+}
+
+export function getAllMarkdownContents(
+  basePath = '',
+  options: GetAllMarkdownContentsOptions = {},
+) {
+  const { includeContent = true } = options; // Default to true
   const contentDir = getContentPath(basePath);
   const allPaths = getAllMarkdownFiles(contentDir);
   const baseSlugArray = basePath.split('/').filter(Boolean);
@@ -21,7 +29,7 @@ export function getAllMarkdownContents(basePath = '') {
       // tags
       const result = matter(markdownContent);
       const item: IMemoItem = {
-        content: result.content,
+        content: includeContent ? result.content : '', // Conditionally include content
         title: result.data.title || slugArray[slugArray.length - 1],
         short_title: result.data.short_title || '',
         description: result.data.description || '',

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -69,7 +69,10 @@ export const getStaticPaths: GetStaticPaths = async () => {
 export const getStaticProps: GetStaticProps = async ({ params }) => {
   try {
     const { slug } = params as { slug: string[] };
-    const allMemos = await getAllMarkdownContents();
+    // Pass includeContent: false as we only need metadata for layout props
+    const allMemos = await getAllMarkdownContents('', {
+      includeContent: false,
+    });
     const layoutProps = await getRootLayoutPageProps(allMemos);
 
     // Try multiple file path options to support Hugo's _index.md convention
@@ -97,7 +100,10 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
       } else if (fs.existsSync(indexFilePath)) {
         filePath = indexFilePath;
       } else if (fs.existsSync(directoryPath)) {
-        const allMemos = await getAllMarkdownContents(slug.join('/'));
+        // Pass includeContent: false as list page only needs title/path
+        const allMemos = await getAllMarkdownContents(slug.join('/'), {
+          includeContent: false,
+        });
         return {
           props: {
             ...layoutProps,


### PR DESCRIPTION
## Problem

Next.js build process showed a warning about large page data (>1MB) for list pages like `/updates`:

```
Warning: data for page "/[...slug]" (path "/updates") is 2.06 MB which exceeds the threshold of 1.05 MB, this amount of data can reduce performance.
```

## Cause

The `getStaticProps` function in `src/pages/[...slug].tsx` was calling `getAllMarkdownContents` twice:
1. Once to fetch all memos for `getRootLayoutPageProps` (used to build the directory tree).
2. A second time (for directory paths like `/updates`) to fetch child memos for the list page.

Both calls loaded the **full content** of the markdown files into memory via `fs.readFileSync` within `getAllMarkdownContents`. This entire dataset, including content not needed for the directory tree or the list page view, was being serialized into the page props, causing the large data size.

## Solution

1.  **Modified `getAllMarkdownContents` (`src/lib/content/memo.ts`):**
    *   Added an optional `options` object parameter with an `includeContent: boolean` flag (defaults to `true`).
    *   The function now only includes the `content` property in the returned `IMemoItem` object if `includeContent` is `true`.
2.  **Modified `getStaticProps` (`src/pages/[...slug].tsx`):**
    *   Updated both calls to `getAllMarkdownContents` to pass `{ includeContent: false }`.
        *   The first call (for layout props) doesn't need content because `buildDirectorTree` only uses metadata.
        *   The second call (for list pages) doesn't need content because the page only displays memo titles and links.

## Expected Outcome

This change significantly reduces the amount of data included in the page props for directory list pages by excluding unnecessary markdown content. This should resolve the large page data warning and improve build performance and potentially runtime performance for these pages.