### PR TITLE
feat: make draft:true truly un-publish (routes/tree/list/backlinks)

### DIFF
--- a/scripts/generate-backlinks.ts
+++ b/scripts/generate-backlinks.ts
@@ -50,7 +50,7 @@ async function generateBacklinksIndex(): Promise<void> {
     const query = `
       SELECT file_path, md_content, title
       FROM read_parquet('${parquetPathForDb}')
-      WHERE md_content IS NOT NULL AND file_path IS NOT NULL AND title IS NOT NULL AND title != '';
+      WHERE md_content IS NOT NULL AND file_path IS NOT NULL AND title IS NOT NULL AND title != '' AND draft IS NOT TRUE;
     `;
 
     console.log('Executing DuckDB query for content data...');

--- a/scripts/generate-static-paths.ts
+++ b/scripts/generate-static-paths.ts
@@ -5,9 +5,43 @@ import {
   getReversedAliasPaths,
   normalizePathWithSlash,
 } from './common.js';
-import { writeFile } from 'fs/promises';
+import { readFile, writeFile, stat } from 'fs/promises';
+import matter from 'gray-matter';
 
 const CONTENT_DIR = path.join(process.cwd(), 'public/content');
+
+/**
+ * A slug from getAllMarkdownFiles may resolve to `<slug>.md`, `<slug>.mdx`, or a
+ * directory index (`<slug>/readme.md`, `<slug>/_index.md`, or just a folder).
+ * Returns true if the underlying source file carries `draft: true`. Directory
+ * entries with no concrete source file are treated as published (the folder
+ * listing already excludes draft children via getAllMarkdownContents).
+ */
+const isDraftSlug = async (slug: string): Promise<boolean> => {
+  const candidates = [
+    `${slug}.md`,
+    `${slug}.mdx`,
+    path.join(slug, 'readme.md'),
+    path.join(slug, 'readme.mdx'),
+    path.join(slug, '_index.md'),
+    path.join(slug, '_index.mdx'),
+  ];
+  for (const candidate of candidates) {
+    const filePath = path.join(CONTENT_DIR, candidate);
+    try {
+      await stat(filePath);
+    } catch {
+      continue;
+    }
+    try {
+      const raw = await readFile(filePath, 'utf-8');
+      return matter(raw).data?.draft === true;
+    } catch {
+      return false;
+    }
+  }
+  return false;
+};
 const STATIC_JSON_PATHS = path.join(
   process.cwd(),
   'public/content/static-paths.json',
@@ -16,13 +50,17 @@ const STATIC_JSON_PATHS = path.join(
 const generateStaticJSONPaths = async () => {
   const redirectsPaths = await getRedirectsNotToAliases();
   const aliasesPaths = await getReversedAliasPaths();
-  const markdownPaths = (await getAllMarkdownFiles(CONTENT_DIR))
+  const allMarkdownSlugs = (await getAllMarkdownFiles(CONTENT_DIR))
     .filter(
       slugArray =>
         !slugArray[0]?.toLowerCase()?.startsWith('contributor') &&
         !slugArray[0]?.toLowerCase()?.startsWith('tags'),
     )
     .map(slugArray => slugArray.join('/'));
+
+  // Exclude draft pages so a draft is never a directly reachable static path.
+  const draftFlags = await Promise.all(allMarkdownSlugs.map(isDraftSlug));
+  const markdownPaths = allMarkdownSlugs.filter((_, i) => !draftFlags[i]);
 
   // Aliases paths as primary paths
   const aliasesEntries = Object.entries(aliasesPaths);

--- a/src/lib/content/memo.ts
+++ b/src/lib/content/memo.ts
@@ -9,13 +9,27 @@ import { memoryCache } from '@/lib/memory-cache';
 
 interface GetAllMarkdownContentsOptions {
   includeContent?: boolean;
+  excludeDrafts?: boolean;
+}
+
+/**
+ * Single source of truth for whether a page is publishable to any surface.
+ *
+ * Only `draft` is enforced today, but the predicate is intentionally written
+ * over a partial frontmatter so additional gates (e.g. `archived`) can be
+ * added here later without touching every call site.
+ */
+export function isPublished(
+  frontmatter: Pick<IMemoItem, 'draft'> | undefined | null,
+): boolean {
+  return !frontmatter?.draft;
 }
 
 export async function getAllMarkdownContents(
   basePath = '',
   options: GetAllMarkdownContentsOptions = {},
 ): Promise<IMemoItem[]> {
-  const { includeContent = true } = options;
+  const { includeContent = true, excludeDrafts = false } = options;
   // Generate a unique cache key based on basePath and options
   const cacheKey = `getAllMarkdownContents:${basePath}:${JSON.stringify(options)}`;
   const cached = memoryCache.get<IMemoItem[]>(cacheKey);
@@ -58,9 +72,10 @@ export async function getAllMarkdownContents(
     return item;
   });
 
-  const memos = (await Promise.all(memoPromises)).filter(
-    Boolean,
-  ) as IMemoItem[];
+  let memos = (await Promise.all(memoPromises)).filter(Boolean) as IMemoItem[];
+  if (excludeDrafts) {
+    memos = memos.filter(isPublished);
+  }
   memoryCache.set(cacheKey, memos);
   return memos;
 }

--- a/src/lib/content/utils.ts
+++ b/src/lib/content/utils.ts
@@ -408,7 +408,7 @@ export async function getRootLayoutPageProps(): Promise<RootLayoutPageProps> {
     // Continue with empty tags if file not found or error occurs
   }
 
-  const memos = await getAllMarkdownContents();
+  const memos = await getAllMarkdownContents('', { excludeDrafts: true });
   const menuSortedPaths = await getMenuPathSorted();
   // Sort the menu data using the sorted paths
   const sortedMenuData = applyRecursiveMenuSortedField(

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -6,7 +6,7 @@ import fs from 'fs/promises';
 
 // Import utility functions
 import { getMarkdownContent } from '../lib/content/markdown';
-import { getAllMarkdownContents } from '@/lib/content/memo';
+import { getAllMarkdownContents, isPublished } from '@/lib/content/memo';
 import {
   getRootLayoutPageProps,
   getServerSideRedirectPath,
@@ -163,6 +163,11 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
       // Extract metadata similar to markdown files for consistency
       const frontmatter: Record<string, any> = mdxSource.frontmatter || {};
 
+      // A draft page must not be reachable by URL in production.
+      if (process.env.NODE_ENV === 'production' && !isPublished(frontmatter)) {
+        return { notFound: true };
+      }
+
       return {
         props: {
           ...layoutProps,
@@ -249,6 +254,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 
         const preMemos = await getAllMarkdownContents(canonicalSlug.join('/'), {
           includeContent: false,
+          excludeDrafts: true,
         });
 
         const allMemos = preMemos.map(memo => {
@@ -274,6 +280,11 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 
     const { content, frontmatter, tocItems, rawContent, blockCount, summary } =
       await getMarkdownContent(filePath);
+
+    // A draft page must not be reachable by URL in production.
+    if (process.env.NODE_ENV === 'production' && !isPublished(frontmatter)) {
+      return { notFound: true };
+    }
 
     const backlinksPath = path.join(
       process.cwd(),

--- a/test/draft-filter.test.ts
+++ b/test/draft-filter.test.ts
@@ -1,0 +1,79 @@
+/**
+ * @file draft-filter.test.ts
+ * @description Tests that `draft: true` frontmatter un-publishes a page.
+ *
+ * Covers:
+ * - the `isPublished` predicate (single source of truth for publishability)
+ * - `getAllMarkdownContents({ excludeDrafts: true })` dropping draft pages
+ *   while keeping published ones (negative control)
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs/promises';
+import path from 'path';
+import { getAllMarkdownContents, isPublished } from '../src/lib/content/memo';
+
+// getAllMarkdownContents reads from <cwd>/public/content, so the fixture has to
+// live there. Use a uniquely-named subdir to avoid clobbering real content.
+const FIXTURE_DIR = 'zzz-draft-filter-test';
+const CONTENT_ROOT = path.join(process.cwd(), 'public/content', FIXTURE_DIR);
+
+const PUBLISHED = `---
+title: Published Probe
+date: '2026-01-01'
+---
+
+Visible body.
+`;
+
+const DRAFT = `---
+title: Draft Probe
+date: '2026-01-01'
+draft: true
+---
+
+Hidden body.
+`;
+
+beforeAll(async () => {
+  await fs.mkdir(CONTENT_ROOT, { recursive: true });
+  await fs.writeFile(path.join(CONTENT_ROOT, 'published.md'), PUBLISHED);
+  await fs.writeFile(path.join(CONTENT_ROOT, 'draft.md'), DRAFT);
+});
+
+afterAll(async () => {
+  await fs.rm(CONTENT_ROOT, { recursive: true, force: true });
+});
+
+describe('isPublished', () => {
+  test('returns true when draft is absent or false', () => {
+    expect(isPublished({})).toBe(true);
+    expect(isPublished({ draft: false })).toBe(true);
+    expect(isPublished(undefined)).toBe(true);
+  });
+
+  test('returns false when draft is true', () => {
+    expect(isPublished({ draft: true })).toBe(false);
+  });
+});
+
+describe('getAllMarkdownContents excludeDrafts', () => {
+  test('excludes draft pages but keeps published ones', async () => {
+    const memos = await getAllMarkdownContents(FIXTURE_DIR, {
+      excludeDrafts: true,
+      includeContent: false,
+    });
+    const titles = memos.map(m => m.title);
+    expect(titles).toContain('Published Probe');
+    expect(titles).not.toContain('Draft Probe');
+  });
+
+  test('negative control: default includes the draft page', async () => {
+    const memos = await getAllMarkdownContents(FIXTURE_DIR, {
+      includeContent: false,
+    });
+    const titles = memos.map(m => m.title);
+    expect(titles).toContain('Published Probe');
+    expect(titles).toContain('Draft Probe');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,12 @@
+import path from 'path';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
   test: {
     watch: false,
     environment: 'node',


### PR DESCRIPTION
## Make `draft: true` truly un-publish a page

Today `draft: true` only hides a note from menu/search/RSS (the parquet-driven surfaces). It still
leaks via: direct route (static-paths), the directory tree, folder/list pages, and backlinks. This
closes those so a draft is gone everywhere. This is the mechanism dfoundation's memo-extraction
Phase 3 (archive) needs to demote ~2,043 lookup/log notes without deleting them.

### Changes
- `src/lib/content/memo.ts`: add `isPublished(frontmatter)` predicate (only `draft` enforced, extensible) + `excludeDrafts` option on `getAllMarkdownContents` (default false, no behavior change elsewhere).
- `src/lib/content/utils.ts`: directory-tree call passes `excludeDrafts: true`.
- `src/pages/[...slug].tsx`: list-page call passes `excludeDrafts: true`; `getStaticProps` returns `notFound` for draft (md + mdx) in production.
- `scripts/generate-static-paths.ts`: drop `draft: true` slugs (the load-bearing fix; routes were the main leak).
- `scripts/generate-backlinks.ts`: add `AND draft IS NOT TRUE` to the parquet SQL.
- `test/draft-filter.test.ts` (new) + `vitest.config.ts` alias.

### Verification (real run)
| Check | Result |
|---|---|
| `vitest run` | 44 passed (4 new) |
| `tsc --noEmit` | 0 errors |
| Probe `draft:true` -> static-paths / search / menu / backlinks | absent from all (0) |
| Negative control (same probe without `draft`) | appears in static-paths |
| `next build` (production) | 1791 pages; probe route NOT emitted; a real page still emitted |

No `db/vault.parquet` or `vault/` change. Generated `public/content/*.json` are gitignored (not committed).
