### PR TITLE
feat(cf-migration): upload derived build artifacts to R2 + D1 rollups

### DIFF
--- a/.github/workflows/derived-to-r2.yml
+++ b/.github/workflows/derived-to-r2.yml
@@ -1,0 +1,68 @@
+name: Upload derived artifacts to R2
+
+# CF-N.4 (memo-track sub-goal 05): builds the site the same way `make
+# build-static` does today, then uploads the artifacts named in the #302
+# build-inventory (db/vault.parquet, the search index, the rendered out/)
+# to R2, plus a small content-metrics rollup to D1.
+#
+# DEPLOY-GATED: this workflow needs the R2 bucket + D1 database provisioned
+# and the secrets below set before a real (non dry-run) run can succeed.
+# Trigger is workflow_dispatch-only for now so it never runs (and never
+# fails on missing secrets) until that's done; flip to a `push: main` trigger
+# once the bucket/database exist. dry_run defaults to true for the same
+# reason - an operator has to opt in to a real upload.
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Resolve + plan only, no network calls to R2/D1'
+        required: false
+        default: true
+        type: boolean
+
+concurrency:
+  group: ${{ github.repository }}-derived-to-r2
+  cancel-in-progress: false
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout contents repo
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 1
+
+      - name: Install devbox
+        uses: jetpack-io/devbox-install-action@v0.12.0
+        with:
+          enable-cache: true
+          devbox-version: 0.14.2
+
+      - name: Build static site (mirrors `make build-static`)
+        shell: bash
+        run: devbox run build-static
+        env:
+          # Existing content-pipeline secrets this build already depends on
+          # (unrelated to R2/D1; same names Railway already uses).
+          PLAUSIBLE_API_TOKEN: ${{ secrets.PLAUSIBLE_API_TOKEN }}
+
+      - name: Upload derived artifacts to R2
+        shell: bash
+        run: pnpm exec tsx scripts/upload-to-r2.ts $DRY_RUN_FLAG
+        env:
+          DRY_RUN_FLAG: ${{ inputs.dry_run && '--dry-run' || '' }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_BUCKET_NAME: ${{ secrets.R2_BUCKET_NAME }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+      - name: Upload content rollup to D1
+        shell: bash
+        run: pnpm exec tsx scripts/upload-rollups-to-d1.ts $DRY_RUN_FLAG
+        env:
+          DRY_RUN_FLAG: ${{ inputs.dry_run && '--dry-run' || '' }}
+          D1_ACCOUNT_ID: ${{ secrets.D1_ACCOUNT_ID }}
+          D1_DATABASE_ID: ${{ secrets.D1_DATABASE_ID }}
+          D1_API_TOKEN: ${{ secrets.D1_API_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "monitor-parquet": "tsx scripts/monitor-parquet.ts",
     "monitor-parquet-notify": "tsx scripts/monitor-parquet.ts --notify",
     "generate-static-paths": "tsx scripts/generate-static-paths.ts",
+    "upload-to-r2": "tsx scripts/upload-to-r2.ts",
+    "upload-rollups-to-d1": "tsx scripts/upload-rollups-to-d1.ts",
     "build-ci-lint": "tsup scripts/formatter/ci-lint.ts --config tsup.config.ts --out-dir out/tools",
     "setup-hook-local": "npx -y tsx scripts/git-shell-hook.ts setup",
     "setup-gh-lint": "npx -y tsx scripts/git-shell-hook.ts github-actions",

--- a/scripts/upload-rollups-to-d1.ts
+++ b/scripts/upload-rollups-to-d1.ts
@@ -1,0 +1,144 @@
+#!/usr/bin/env tsx
+
+/**
+ * Roll the vault.parquet content metrics up into a small D1 table so
+ * consumers (fortress memo-analytics, etc.) can query build-health numbers
+ * without loading the whole parquet (CF-N.4's "rollups to D1").
+ *
+ * Reuses collectVaultMetrics from monitor-vault-parquet.ts (same DuckDB
+ * query this repo already runs) rather than re-querying the parquet here.
+ *
+ * Usage:
+ *   tsx scripts/upload-rollups-to-d1.ts             # real upload, needs D1_* env
+ *   tsx scripts/upload-rollups-to-d1.ts --dry-run   # compute + log only
+ */
+
+import { execSync } from 'child_process';
+import { collectVaultMetrics } from './monitor-vault-parquet';
+
+export interface ContentRollup {
+  commitSha: string;
+  generatedAt: string;
+  totalRecords: number;
+  drafts: number;
+  pinned: number;
+  missingEmbeddings: number;
+}
+
+export async function computeRollup(commitSha: string): Promise<ContentRollup> {
+  const metrics = await collectVaultMetrics();
+  return {
+    commitSha,
+    generatedAt: new Date().toISOString(),
+    totalRecords: metrics.totalRecords,
+    drafts: metrics.drafts,
+    pinned: metrics.pinned,
+    missingEmbeddings: metrics.missingEmbeddings,
+  };
+}
+
+export interface D1Client {
+  execute(sql: string, params?: unknown[]): Promise<unknown>;
+}
+
+export const CREATE_ROLLUP_TABLE_SQL = `CREATE TABLE IF NOT EXISTS content_rollups (
+  commit_sha TEXT PRIMARY KEY,
+  generated_at TEXT NOT NULL,
+  total_records INTEGER NOT NULL,
+  drafts INTEGER NOT NULL,
+  pinned INTEGER NOT NULL,
+  missing_embeddings INTEGER NOT NULL
+)`;
+
+// keyed by commit_sha: a re-run for the same commit replaces the row instead
+// of inserting a duplicate.
+export const UPSERT_ROLLUP_SQL = `INSERT INTO content_rollups
+  (commit_sha, generated_at, total_records, drafts, pinned, missing_embeddings)
+  VALUES (?, ?, ?, ?, ?, ?)
+  ON CONFLICT(commit_sha) DO UPDATE SET
+    generated_at = excluded.generated_at,
+    total_records = excluded.total_records,
+    drafts = excluded.drafts,
+    pinned = excluded.pinned,
+    missing_embeddings = excluded.missing_embeddings`;
+
+export async function uploadRollup(
+  client: D1Client,
+  rollup: ContentRollup,
+  opts: { dryRun?: boolean } = {},
+): Promise<void> {
+  if (opts.dryRun) {
+    console.log('[dry-run] would execute:\n', CREATE_ROLLUP_TABLE_SQL);
+    console.log('[dry-run] would execute:\n', UPSERT_ROLLUP_SQL, rollup);
+    return;
+  }
+  await client.execute(CREATE_ROLLUP_TABLE_SQL);
+  await client.execute(UPSERT_ROLLUP_SQL, [
+    rollup.commitSha,
+    rollup.generatedAt,
+    rollup.totalRecords,
+    rollup.drafts,
+    rollup.pinned,
+    rollup.missingEmbeddings,
+  ]);
+}
+
+function requireEnv(env: NodeJS.ProcessEnv, name: string): string {
+  const value = env[name];
+  if (!value) {
+    throw new Error(`Missing required env var: ${name}`);
+  }
+  return value;
+}
+
+function createD1ClientFromEnv(env: NodeJS.ProcessEnv = process.env): D1Client {
+  const accountId = requireEnv(env, 'D1_ACCOUNT_ID');
+  const databaseId = requireEnv(env, 'D1_DATABASE_ID');
+  const apiToken = requireEnv(env, 'D1_API_TOKEN');
+  const url = `https://api.cloudflare.com/client/v4/accounts/${accountId}/d1/database/${databaseId}/query`;
+
+  return {
+    async execute(sql, params = []) {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${apiToken}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ sql, params }),
+      });
+      const json: any = await res.json().catch(() => ({}));
+      if (!res.ok || json?.success === false) {
+        throw new Error(`D1 query failed: ${res.status} ${JSON.stringify(json?.errors ?? json)}`);
+      }
+      return json;
+    },
+  };
+}
+
+async function main() {
+  const dryRun = process.argv.includes('--dry-run');
+  const commitSha =
+    process.env.GITHUB_SHA?.trim() || execSync('git rev-parse HEAD').toString().trim();
+
+  const rollup = await computeRollup(commitSha);
+  console.log(`Computed rollup for ${commitSha}${dryRun ? ' [dry-run]' : ''}:`, rollup);
+
+  const client: D1Client = dryRun
+    ? {
+        execute: async () => {
+          throw new Error('D1Client.execute should not be called in --dry-run');
+        },
+      }
+    : createD1ClientFromEnv();
+
+  await uploadRollup(client, rollup, { dryRun });
+  console.log(dryRun ? 'Dry-run complete.' : 'Rollup uploaded to D1.');
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch(error => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/scripts/upload-to-r2.ts
+++ b/scripts/upload-to-r2.ts
@@ -1,0 +1,362 @@
+#!/usr/bin/env tsx
+
+/**
+ * Upload the memo.d.foundation build's derived artifacts to Cloudflare R2.
+ *
+ * Artifact list is the exact set named in the #302 build-inventory
+ * (docs/cf-migration/build-inventory.md): db/vault.parquet (carries the
+ * embeddings), the search index, and the rendered `out/` tree. No other
+ * paths are invented here.
+ *
+ * Each file is uploaded to two keys so a re-run never duplicates objects:
+ *   derived/<commitSha>/<relKey>  - immutable, one object per commit
+ *   derived/latest/<relKey>       - mutable pointer consumers should read
+ * A HEAD-before-PUT content-hash check skips the write entirely when the
+ * object at that key already has the same content (real R2 client only;
+ * dry-run never touches the network).
+ *
+ * Usage:
+ *   tsx scripts/upload-to-r2.ts             # real upload, needs R2_* env
+ *   tsx scripts/upload-to-r2.ts --dry-run   # resolve + plan only, no network
+ */
+
+import fs from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+import { execSync } from 'child_process';
+
+export type ArtifactKind = 'vault-db' | 'search-index' | 'rendered';
+
+export interface ArtifactSource {
+  kind: ArtifactKind;
+  localPath: string;
+  relKey: string;
+}
+
+// Exactly the artifacts named in #302's build-inventory.md for N.4/N.5.
+// Do not add paths here without a matching row in that inventory.
+const CORE_ARTIFACTS: Array<{
+  kind: ArtifactKind;
+  localRelPath: string;
+  relKey: string;
+}> = [
+  { kind: 'vault-db', localRelPath: 'db/vault.parquet', relKey: 'db/vault.parquet' },
+  {
+    kind: 'search-index',
+    localRelPath: 'public/content/search-index.json',
+    relKey: 'search-index.json',
+  },
+];
+
+function walkDir(root: string, base = ''): string[] {
+  const entries = fs.readdirSync(path.join(root, base), { withFileTypes: true });
+  let out: string[] = [];
+  for (const entry of entries) {
+    const rel = base ? path.join(base, entry.name) : entry.name;
+    if (entry.isDirectory()) {
+      out = out.concat(walkDir(root, rel));
+    } else {
+      out.push(rel);
+    }
+  }
+  return out;
+}
+
+function toPosix(relPath: string): string {
+  return relPath.split(path.sep).join('/');
+}
+
+export function resolveArtifacts(repoRoot: string): {
+  found: ArtifactSource[];
+  missing: string[];
+} {
+  const found: ArtifactSource[] = [];
+  const missing: string[] = [];
+
+  for (const artifact of CORE_ARTIFACTS) {
+    const localPath = path.join(repoRoot, artifact.localRelPath);
+    if (fs.existsSync(localPath) && fs.statSync(localPath).isFile()) {
+      found.push({ kind: artifact.kind, localPath, relKey: artifact.relKey });
+    } else {
+      missing.push(artifact.localRelPath);
+    }
+  }
+
+  const outDir = path.join(repoRoot, 'out');
+  if (fs.existsSync(outDir) && fs.statSync(outDir).isDirectory()) {
+    const files = walkDir(outDir);
+    if (files.length === 0) {
+      missing.push('out/ (empty)');
+    }
+    for (const relFile of files) {
+      found.push({
+        kind: 'rendered',
+        localPath: path.join(outDir, relFile),
+        relKey: toPosix(path.join('out', relFile)),
+      });
+    }
+  } else {
+    missing.push('out/');
+  }
+
+  return { found, missing };
+}
+
+function guessContentType(relKey: string): string {
+  const ext = path.extname(relKey).toLowerCase();
+  switch (ext) {
+    case '.parquet':
+      return 'application/octet-stream';
+    case '.json':
+      return 'application/json';
+    case '.html':
+      return 'text/html; charset=utf-8';
+    case '.xml':
+      return 'application/xml';
+    case '.js':
+      return 'text/javascript; charset=utf-8';
+    case '.css':
+      return 'text/css; charset=utf-8';
+    case '.svg':
+      return 'image/svg+xml';
+    case '.png':
+      return 'image/png';
+    case '.jpg':
+    case '.jpeg':
+      return 'image/jpeg';
+    case '.webp':
+      return 'image/webp';
+    case '.txt':
+      return 'text/plain; charset=utf-8';
+    default:
+      return 'application/octet-stream';
+  }
+}
+
+export interface R2Client {
+  headObject(key: string): Promise<{ contentSha256?: string } | null>;
+  putObject(
+    key: string,
+    body: Buffer,
+    opts: { contentType: string; contentSha256: string },
+  ): Promise<void>;
+}
+
+export interface UploadPlan {
+  key: string;
+  relKey: string;
+  kind: ArtifactKind;
+  sizeBytes: number;
+  sha256: string;
+  action: 'upload' | 'skip-unchanged' | 'dry-run';
+}
+
+export async function uploadArtifacts(
+  client: R2Client,
+  artifacts: ArtifactSource[],
+  opts: { commitSha: string; dryRun?: boolean },
+): Promise<UploadPlan[]> {
+  const plans: UploadPlan[] = [];
+
+  for (const artifact of artifacts) {
+    const body = fs.readFileSync(artifact.localPath);
+    const sha256 = crypto.createHash('sha256').update(body).digest('hex');
+    const contentType = guessContentType(artifact.relKey);
+
+    const keys = [
+      `derived/${opts.commitSha}/${artifact.relKey}`,
+      `derived/latest/${artifact.relKey}`,
+    ];
+
+    for (const key of keys) {
+      let action: UploadPlan['action'] = 'upload';
+
+      if (opts.dryRun) {
+        action = 'dry-run';
+      } else {
+        const existing = await client.headObject(key);
+        if (existing?.contentSha256 === sha256) {
+          action = 'skip-unchanged';
+        }
+      }
+
+      if (action === 'upload') {
+        await client.putObject(key, body, { contentType, contentSha256: sha256 });
+      }
+
+      plans.push({
+        key,
+        relKey: artifact.relKey,
+        kind: artifact.kind,
+        sizeBytes: body.length,
+        sha256,
+        action,
+      });
+    }
+  }
+
+  return plans;
+}
+
+function requireEnv(env: NodeJS.ProcessEnv, name: string): string {
+  const value = env[name];
+  if (!value) {
+    throw new Error(`Missing required env var: ${name}`);
+  }
+  return value;
+}
+
+function hmac(key: Buffer | string, data: string): Buffer {
+  return crypto.createHmac('sha256', key).update(data, 'utf8').digest();
+}
+
+function sha256hex(data: Buffer | string): string {
+  return crypto.createHash('sha256').update(data).digest('hex');
+}
+
+function toAmzDate(now: Date): { amzDate: string; dateStamp: string } {
+  const amzDate = now.toISOString().replace(/[:-]|\.\d{3}/g, '');
+  return { amzDate, dateStamp: amzDate.slice(0, 8) };
+}
+
+// ponytail: hand-rolled SigV4 instead of pulling in aws4fetch (rung 3, stdlib
+// crypto only; no new dependency to add/lock in this worktree). Untested
+// against live R2 (deploy-gated, see goal Notes) - if R2 ever 403s on a real
+// upload, verify against Cloudflare's R2 S3-API signing example first.
+function createR2ClientFromEnv(env: NodeJS.ProcessEnv = process.env): R2Client {
+  const accountId = requireEnv(env, 'R2_ACCOUNT_ID');
+  const bucket = requireEnv(env, 'R2_BUCKET_NAME');
+  const accessKeyId = requireEnv(env, 'R2_ACCESS_KEY_ID');
+  const secretAccessKey = requireEnv(env, 'R2_SECRET_ACCESS_KEY');
+  const region = 'auto';
+  const service = 's3';
+  const host = `${accountId}.r2.cloudflarestorage.com`;
+
+  async function signedRequest(
+    method: string,
+    key: string,
+    body: Buffer | undefined,
+    extraHeaders: Record<string, string>,
+  ): Promise<Response> {
+    const now = new Date();
+    const { amzDate, dateStamp } = toAmzDate(now);
+    const payloadHash = sha256hex(body ?? Buffer.alloc(0));
+    const canonicalUri = `/${bucket}/${key
+      .split('/')
+      .map(seg => encodeURIComponent(seg))
+      .join('/')}`;
+
+    const headers: Record<string, string> = {
+      host,
+      'x-amz-content-sha256': payloadHash,
+      'x-amz-date': amzDate,
+      ...extraHeaders,
+    };
+    const signedHeaderNames = Object.keys(headers)
+      .map(h => h.toLowerCase())
+      .sort();
+    const headerByLower = Object.fromEntries(
+      Object.entries(headers).map(([k, v]) => [k.toLowerCase(), v.trim()]),
+    );
+    const canonicalHeaders = signedHeaderNames.map(h => `${h}:${headerByLower[h]}\n`).join('');
+    const signedHeaders = signedHeaderNames.join(';');
+    const canonicalRequest = [
+      method,
+      canonicalUri,
+      '',
+      canonicalHeaders,
+      signedHeaders,
+      payloadHash,
+    ].join('\n');
+    const credentialScope = `${dateStamp}/${region}/${service}/aws4_request`;
+    const stringToSign = [
+      'AWS4-HMAC-SHA256',
+      amzDate,
+      credentialScope,
+      sha256hex(canonicalRequest),
+    ].join('\n');
+
+    const kDate = hmac(`AWS4${secretAccessKey}`, dateStamp);
+    const kRegion = hmac(kDate, region);
+    const kService = hmac(kRegion, service);
+    const kSigning = hmac(kService, 'aws4_request');
+    const signature = crypto.createHmac('sha256', kSigning).update(stringToSign, 'utf8').digest('hex');
+
+    const authorization = `AWS4-HMAC-SHA256 Credential=${accessKeyId}/${credentialScope}, SignedHeaders=${signedHeaders}, Signature=${signature}`;
+
+    return fetch(`https://${host}${canonicalUri}`, {
+      method,
+      headers: { ...headers, authorization },
+      body,
+    });
+  }
+
+  return {
+    async headObject(key) {
+      const res = await signedRequest('HEAD', key, undefined, {});
+      if (res.status === 404) return null;
+      if (!res.ok) {
+        throw new Error(`R2 HEAD ${key} failed: ${res.status}`);
+      }
+      const contentSha256 = res.headers.get('x-amz-meta-content-sha256') ?? undefined;
+      return { contentSha256 };
+    },
+    async putObject(key, body, opts) {
+      const res = await signedRequest('PUT', key, body, {
+        'content-type': opts.contentType,
+        'x-amz-meta-content-sha256': opts.contentSha256,
+      });
+      if (!res.ok) {
+        const text = await res.text().catch(() => '');
+        throw new Error(`R2 PUT ${key} failed: ${res.status} ${text}`);
+      }
+    },
+  };
+}
+
+async function main() {
+  const dryRun = process.argv.includes('--dry-run');
+  const repoRoot = process.cwd();
+  const commitSha =
+    process.env.GITHUB_SHA?.trim() ||
+    execSync('git rev-parse HEAD', { cwd: repoRoot }).toString().trim();
+
+  const { found, missing } = resolveArtifacts(repoRoot);
+
+  if (missing.length > 0) {
+    console.error(`Required artifact(s) missing, cannot proceed: ${missing.join(', ')}`);
+    process.exit(1);
+    return;
+  }
+
+  console.log(
+    `Resolved ${found.length} artifact file(s) for commit ${commitSha}${dryRun ? ' [dry-run]' : ''}`,
+  );
+
+  const client: R2Client = dryRun
+    ? {
+        headObject: async () => {
+          throw new Error('R2Client.headObject should not be called in --dry-run');
+        },
+        putObject: async () => {
+          throw new Error('R2Client.putObject should not be called in --dry-run');
+        },
+      }
+    : createR2ClientFromEnv();
+
+  const plans = await uploadArtifacts(client, found, { commitSha, dryRun });
+
+  for (const plan of plans) {
+    console.log(
+      `${plan.action.padEnd(14)} ${plan.key} (${plan.sizeBytes}B, sha256:${plan.sha256.slice(0, 12)})`,
+    );
+  }
+  console.log(`Done. ${plans.length} object write(s) planned/executed.`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch(error => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/test/upload-rollups-to-d1.test.ts
+++ b/test/upload-rollups-to-d1.test.ts
@@ -1,0 +1,105 @@
+/**
+ * @file upload-rollups-to-d1.test.ts
+ * @description Unit tests + a dry-run against a mocked D1 client for
+ * scripts/upload-rollups-to-d1.ts (CF-N.4's "rollups to D1").
+ */
+
+import { describe, test, expect, vi } from 'vitest';
+
+vi.mock('../scripts/monitor-vault-parquet', () => ({
+  collectVaultMetrics: vi.fn(async () => ({
+    totalRecords: 2031,
+    fileSizeMB: 45,
+    fileAgeHours: 2,
+    drafts: 150,
+    pinned: 25,
+    pendingMint: 5,
+    pendingArweave: 8,
+    missingEmbeddings: 44,
+    emptyContent: 3,
+    missingDates: 100,
+    missingAuthors: 150,
+    avgTokens: 2500,
+    minTokens: 50,
+    maxTokens: 15000,
+    missingDatesPercent: 5,
+    missingAuthorsPercent: 7,
+  })),
+}));
+
+import {
+  computeRollup,
+  uploadRollup,
+  CREATE_ROLLUP_TABLE_SQL,
+  UPSERT_ROLLUP_SQL,
+  type D1Client,
+} from '../scripts/upload-rollups-to-d1';
+
+describe('computeRollup', () => {
+  test('derives the rollup from collectVaultMetrics, keyed by commit sha', async () => {
+    const rollup = await computeRollup('deadbeef');
+
+    expect(rollup.commitSha).toBe('deadbeef');
+    expect(rollup.totalRecords).toBe(2031);
+    expect(rollup.drafts).toBe(150);
+    expect(rollup.pinned).toBe(25);
+    expect(rollup.missingEmbeddings).toBe(44);
+    expect(() => new Date(rollup.generatedAt).toISOString()).not.toThrow();
+  });
+});
+
+function createRecordingD1Client(): { client: D1Client; calls: Array<{ sql: string; params?: unknown[] }> } {
+  const calls: Array<{ sql: string; params?: unknown[] }> = [];
+  const client: D1Client = {
+    async execute(sql, params) {
+      calls.push({ sql, params });
+      return { success: true };
+    },
+  };
+  return { client, calls };
+}
+
+describe('uploadRollup', () => {
+  test('creates the table then upserts, keyed by commit_sha (idempotent re-run)', async () => {
+    const { client, calls } = createRecordingD1Client();
+    const rollup = await computeRollup('deadbeef');
+
+    await uploadRollup(client, rollup);
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0].sql).toBe(CREATE_ROLLUP_TABLE_SQL);
+    expect(calls[1].sql).toBe(UPSERT_ROLLUP_SQL);
+    expect(calls[1].params).toEqual([
+      'deadbeef',
+      rollup.generatedAt,
+      2031,
+      150,
+      25,
+      44,
+    ]);
+    expect(UPSERT_ROLLUP_SQL).toMatch(/ON CONFLICT\(commit_sha\) DO UPDATE/);
+  });
+
+  test('a re-run for the same commit replaces the row (same params, no new PK)', async () => {
+    const { client, calls } = createRecordingD1Client();
+    const rollup = await computeRollup('deadbeef');
+
+    await uploadRollup(client, rollup);
+    await uploadRollup(client, rollup);
+
+    const upserts = calls.filter(c => c.sql === UPSERT_ROLLUP_SQL);
+    expect(upserts).toHaveLength(2);
+    expect(upserts[0].params?.[0]).toBe(upserts[1].params?.[0]);
+  });
+
+  test('dry-run never touches the client (asserts against a client that throws if called)', async () => {
+    const throwingClient: D1Client = {
+      execute: async () => {
+        throw new Error('execute must not be called during dry-run');
+      },
+    };
+    const rollup = await computeRollup('deadbeef');
+
+    await expect(uploadRollup(throwingClient, rollup, { dryRun: true })).resolves.toBeUndefined();
+  });
+});

--- a/test/upload-to-r2.test.ts
+++ b/test/upload-to-r2.test.ts
@@ -1,0 +1,179 @@
+/**
+ * @file upload-to-r2.test.ts
+ * @description Unit tests + a dry-run against a mocked R2 client for
+ * scripts/upload-to-r2.ts. Artifact paths mirror #302's build-inventory.md
+ * exactly (db/vault.parquet, public/content/search-index.json, out/**).
+ */
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import crypto from 'crypto';
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import { resolveArtifacts, uploadArtifacts, type R2Client } from '../scripts/upload-to-r2';
+
+let repoRoot: string;
+
+function writeFile(relPath: string, content: string) {
+  const full = path.join(repoRoot, relPath);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content);
+}
+
+function makeFullFixture() {
+  writeFile('db/vault.parquet', 'fake-parquet-bytes');
+  writeFile('public/content/search-index.json', '{"docs":[]}');
+  writeFile('out/index.html', '<html>home</html>');
+  writeFile('out/assets/app.js', 'console.log(1)');
+}
+
+beforeEach(() => {
+  repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'memo-r2-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(repoRoot, { recursive: true, force: true });
+});
+
+describe('resolveArtifacts', () => {
+  test('finds exactly the #302 inventory paths when the build is complete', () => {
+    makeFullFixture();
+
+    const { found, missing } = resolveArtifacts(repoRoot);
+
+    expect(missing).toEqual([]);
+    const relKeys = found.map(a => a.relKey).sort();
+    expect(relKeys).toEqual(
+      ['db/vault.parquet', 'search-index.json', 'out/assets/app.js', 'out/index.html'].sort(),
+    );
+
+    const vaultDb = found.find(a => a.kind === 'vault-db');
+    expect(vaultDb?.localPath).toBe(path.join(repoRoot, 'db/vault.parquet'));
+
+    const searchIndex = found.find(a => a.kind === 'search-index');
+    expect(searchIndex?.relKey).toBe('search-index.json');
+
+    const rendered = found.filter(a => a.kind === 'rendered');
+    expect(rendered).toHaveLength(2);
+  });
+
+  test('reports missing artifacts by their #302 path, no invented paths', () => {
+    // Only the vault db exists; search index and out/ are absent.
+    writeFile('db/vault.parquet', 'fake-parquet-bytes');
+
+    const { found, missing } = resolveArtifacts(repoRoot);
+
+    expect(found).toHaveLength(1);
+    expect(missing).toEqual(['public/content/search-index.json', 'out/']);
+  });
+
+  test('treats an empty out/ dir as missing (nothing rendered to upload)', () => {
+    writeFile('db/vault.parquet', 'x');
+    writeFile('public/content/search-index.json', '{}');
+    fs.mkdirSync(path.join(repoRoot, 'out'), { recursive: true });
+
+    const { missing } = resolveArtifacts(repoRoot);
+
+    expect(missing).toEqual(['out/ (empty)']);
+  });
+});
+
+function createRecordingClient(existingShaByKey: Record<string, string> = {}): {
+  client: R2Client;
+  puts: Array<{ key: string; body: Buffer; contentType: string; contentSha256: string }>;
+} {
+  const puts: Array<{ key: string; body: Buffer; contentType: string; contentSha256: string }> = [];
+  const client: R2Client = {
+    async headObject(key) {
+      const sha = existingShaByKey[key];
+      return sha ? { contentSha256: sha } : null;
+    },
+    async putObject(key, body, opts) {
+      puts.push({ key, body, ...opts });
+    },
+  };
+  return { client, puts };
+}
+
+describe('uploadArtifacts', () => {
+  test('uploads each artifact to a commit-scoped key and a latest key', async () => {
+    makeFullFixture();
+    const { found } = resolveArtifacts(repoRoot);
+    const { client, puts } = createRecordingClient();
+
+    const plans = await uploadArtifacts(client, found, { commitSha: 'abc1234' });
+
+    // one commit-scoped + one latest key per artifact file
+    expect(plans).toHaveLength(found.length * 2);
+    expect(puts).toHaveLength(found.length * 2);
+
+    const vaultPlans = plans.filter(p => p.relKey === 'db/vault.parquet');
+    expect(vaultPlans.map(p => p.key).sort()).toEqual(
+      ['derived/abc1234/db/vault.parquet', 'derived/latest/db/vault.parquet'].sort(),
+    );
+    expect(vaultPlans.every(p => p.action === 'upload')).toBe(true);
+
+    const searchPut = puts.find(p => p.key === 'derived/latest/search-index.json');
+    expect(searchPut?.contentType).toBe('application/json');
+
+    const jsPut = puts.find(p => p.key === 'derived/latest/out/assets/app.js');
+    expect(jsPut?.contentType).toBe('text/javascript; charset=utf-8');
+  });
+
+  test('is idempotent: a re-run with unchanged content skips the write (no duplicate)', async () => {
+    makeFullFixture();
+    const { found } = resolveArtifacts(repoRoot);
+    const vaultBody = fs.readFileSync(path.join(repoRoot, 'db/vault.parquet'));
+    const vaultSha = crypto.createHash('sha256').update(vaultBody).digest('hex');
+
+    const { client, puts } = createRecordingClient({
+      'derived/abc1234/db/vault.parquet': vaultSha,
+      'derived/latest/db/vault.parquet': vaultSha,
+    });
+
+    const plans = await uploadArtifacts(client, found, { commitSha: 'abc1234' });
+
+    const vaultPlans = plans.filter(p => p.relKey === 'db/vault.parquet');
+    expect(vaultPlans.every(p => p.action === 'skip-unchanged')).toBe(true);
+    expect(puts.some(p => p.key.endsWith('db/vault.parquet'))).toBe(false);
+
+    // other artifacts (no matching sha recorded) still upload
+    const searchPlans = plans.filter(p => p.relKey === 'search-index.json');
+    expect(searchPlans.every(p => p.action === 'upload')).toBe(true);
+  });
+
+  test('changed content re-uploads even if the key already exists', async () => {
+    makeFullFixture();
+    const { found } = resolveArtifacts(repoRoot);
+    const { client, puts } = createRecordingClient({
+      'derived/abc1234/db/vault.parquet': 'stale-sha-does-not-match',
+    });
+
+    const plans = await uploadArtifacts(client, found, { commitSha: 'abc1234' });
+
+    const scoped = plans.find(p => p.key === 'derived/abc1234/db/vault.parquet');
+    expect(scoped?.action).toBe('upload');
+    expect(puts.some(p => p.key === 'derived/abc1234/db/vault.parquet')).toBe(true);
+  });
+
+  test('dry-run never touches the client (asserts against a client that throws if called)', async () => {
+    makeFullFixture();
+    const { found } = resolveArtifacts(repoRoot);
+    const throwingClient: R2Client = {
+      headObject: async () => {
+        throw new Error('headObject must not be called during dry-run');
+      },
+      putObject: async () => {
+        throw new Error('putObject must not be called during dry-run');
+      },
+    };
+
+    const plans = await uploadArtifacts(throwingClient, found, {
+      commitSha: 'abc1234',
+      dryRun: true,
+    });
+
+    expect(plans.every(p => p.action === 'dry-run')).toBe(true);
+    expect(plans).toHaveLength(found.length * 2);
+  });
+});


### PR DESCRIPTION
## Outcome

CI uploads the build's derived artifacts (`db/vault.parquet` with embeddings, the
search index, the rendered `out/`) to R2 under a commit-scoped key + a `latest`
pointer key, plus a small content-metrics rollup to D1 (CF-N.4). Artifact paths
are the exact three named in this sub-goal's Outcome, cross-checked against
#302's `docs/cf-migration/build-inventory.md`, no invented paths (`db/processing_metadata*.parquet`
is deliberately excluded, per #302 it's "only used by the Elixir incremental-export
cache, not by the TS/Next layer").

- `scripts/upload-to-r2.ts`: hand-rolled SigV4 (Node `crypto`, no new
  dependency) behind an injectable `R2Client` interface. Idempotent: each
  artifact writes to `derived/<commitSha>/<relKey>` (immutable per commit) and
  `derived/latest/<relKey>` (the pointer consumers should read); a
  HEAD-before-PUT content-sha256 check skips the write when unchanged.
- `scripts/upload-rollups-to-d1.ts`: reuses `collectVaultMetrics` from the
  existing `monitor-vault-parquet.ts` (no re-querying the parquet), upserts one
  row per commit into a new `content_rollups` table via the D1 HTTP API.
- `.github/workflows/derived-to-r2.yml`: runs both after `make build-static`.
  `workflow_dispatch`-only, `dry_run` input defaulting to `true` (deploy-gated,
  see below). Secrets referenced by name only.

## Verify

- `pnpm exec vitest run`: 55/55 green (44 pre-existing + 11 new,
  `test/upload-to-r2.test.ts` + `test/upload-rollups-to-d1.test.ts`), both
  against a mocked `R2Client`/`D1Client` asserting the exact keys/SQL, plus an
  idempotency test (unchanged content -> `skip-unchanged`, no duplicate PUT)
  and a dry-run test (client that throws if called at all, never called).
- `tsc --noEmit` clean on both new scripts.
- Two real CLI dry-runs (not just mocked unit tests): `tsx scripts/upload-to-r2.ts
  --dry-run` against this worktree unbuilt correctly exits 1 and names the two
  missing paths; against a scratch fixture tree with all three artifact paths
  present it exits 0 and prints the 8 correct `derived/...` keys.
  `tsx scripts/upload-rollups-to-d1.ts --dry-run` ran for real against this
  worktree's actual committed `db/vault.parquet` (real DuckDB query) and
  returned a real rollup.
- Could not run `eslint` on the new files (pre-existing environment drift
  between the borrowed `node_modules` and this worktree's `eslint.config.mjs`,
  unrelated to the new code); `tsc --noEmit` is the substitute evidence.

## Fingerprint (deploy-gated, not built here)

Live upload needs: the R2 bucket provisioned, a D1 database created +
migrated with `content_rollups`, and 7 repo secrets (names only):
`R2_ACCOUNT_ID`, `R2_BUCKET_NAME`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`,
`D1_ACCOUNT_ID`, `D1_DATABASE_ID`, `D1_API_TOKEN`. The SigV4 signing code is
untested against a live R2 endpoint for the same reason. Separately
(pre-existing, not introduced here): a fresh CI run of `make build-static`
still needs the content pipeline's own secrets (`PLAUSIBLE_API_TOKEN`, the
`StorageUtil` bucket creds) per #302's own findings.

## Roadmap

dfoundation `projects/cloudflare-migration/megagoals/memo-track/ROADMAP.md`, sub-goal 05.

## Scope

No live upload, no R2/D1 provisioning, no rewrite of the Elixir compiler or
the existing generate-*.ts scripts. Depends on #302 (build-inventory).
