### PR TITLE
feat(cf-migration): per-post memo_posts export completing the DuckDB-kill

### DIFF
--- a/scripts/d1-env-client.ts
+++ b/scripts/d1-env-client.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared Cloudflare D1 HTTP client, factored out of upload-rollups-to-d1.ts
+ * (#303) so upload-memo-posts-to-d1.ts can reuse the exact same env-var
+ * contract (D1_ACCOUNT_ID / D1_DATABASE_ID / D1_API_TOKEN) instead of a
+ * second copy of the same fetch wrapper.
+ */
+
+export interface D1Client {
+  execute(sql: string, params?: unknown[]): Promise<unknown>;
+}
+
+export function requireEnv(env: NodeJS.ProcessEnv, name: string): string {
+  const value = env[name];
+  if (!value) {
+    throw new Error(`Missing required env var: ${name}`);
+  }
+  return value;
+}
+
+export function createD1ClientFromEnv(env: NodeJS.ProcessEnv = process.env): D1Client {
+  const accountId = requireEnv(env, 'D1_ACCOUNT_ID');
+  const databaseId = requireEnv(env, 'D1_DATABASE_ID');
+  const apiToken = requireEnv(env, 'D1_API_TOKEN');
+  const url = `https://api.cloudflare.com/client/v4/accounts/${accountId}/d1/database/${databaseId}/query`;
+
+  return {
+    async execute(sql, params = []) {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${apiToken}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ sql, params }),
+      });
+      const json: any = await res.json().catch(() => ({}));
+      if (!res.ok || json?.success === false) {
+        throw new Error(`D1 query failed: ${res.status} ${JSON.stringify(json?.errors ?? json)}`);
+      }
+      return json;
+    },
+  };
+}

--- a/scripts/extract-memo-posts.ts
+++ b/scripts/extract-memo-posts.ts
@@ -1,0 +1,61 @@
+/**
+ * Extract per-post rows from db/vault.parquet, shaped to match EXACTLY what
+ * fortress-api's Discord DuckDB path reads off this same file:
+ *   fortress-api/pkg/handler/discord/discord.go
+ *     - getMemosFromParquet: date, title, authors, tags, file_path (+ content,
+ *       see note below)
+ *     - resolveAuthorsFromParquetByTitle: title, authors
+ *
+ * `content` is NOT reproduced here: discord.go reads row["content"], but
+ * vault.parquet has no "content" column (only "md_content"), so that field
+ * is always empty in production today -- a pre-existing fortress-side no-op,
+ * confirmed by cross-checking this repo's real schema, not carried forward
+ * into memo_posts.
+ *
+ * Rows with no title or file_path are dropped (not real posts; vault.parquet
+ * also carries author-profile rows with those columns unset).
+ */
+
+import { DuckDBInstance } from '@duckdb/node-api';
+
+export interface MemoPostRow {
+  filePath: string;
+  date: string | null;
+  title: string;
+  authors: string[];
+  tags: string[];
+}
+
+export async function extractMemoPosts(vaultParquetPath: string): Promise<MemoPostRow[]> {
+  const instance = await DuckDBInstance.create(':memory:');
+  const connection = await instance.connect();
+  try {
+    // to_json() on the LIST columns is deliberate: @duckdb/node-api returns
+    // LIST values as a `{ items: [...] }` wrapper, not a plain JS array, so
+    // to_json()+JSON.parse gets a real string[] without depending on that
+    // wrapper's shape. strftime() likewise turns the DuckDBDateValue struct
+    // into a plain ISO string (or SQL NULL -> JS null) up front.
+    const result = await connection.runAndReadAll(`
+      SELECT
+        file_path,
+        strftime(date, '%Y-%m-%d') AS date,
+        title,
+        to_json(authors) AS authors_json,
+        to_json(tags) AS tags_json
+      FROM read_parquet('${vaultParquetPath}')
+      WHERE title IS NOT NULL AND title != ''
+        AND file_path IS NOT NULL AND file_path != ''
+      ORDER BY file_path
+    `);
+
+    return result.getRowObjects().map(row => ({
+      filePath: String(row.file_path),
+      date: row.date == null ? null : String(row.date),
+      title: String(row.title),
+      authors: JSON.parse(String(row.authors_json ?? '[]')),
+      tags: JSON.parse(String(row.tags_json ?? '[]')),
+    }));
+  } finally {
+    connection.closeSync();
+  }
+}

--- a/scripts/upload-memo-posts-to-d1.ts
+++ b/scripts/upload-memo-posts-to-d1.ts
@@ -1,0 +1,96 @@
+#!/usr/bin/env tsx
+
+/**
+ * Upload PER-POST rows (not the aggregate content_rollups of #303) to a D1
+ * `memo_posts` table, keyed by file_path -- the exact per-post shape
+ * fortress-api's Discord DuckDB queries need (see extract-memo-posts.ts for
+ * the discord.go column cross-check). Completes the DuckDB-kill that #303's
+ * aggregate-only rollup left unfinished (M4-06).
+ *
+ * Usage:
+ *   tsx scripts/upload-memo-posts-to-d1.ts             # real upload, needs D1_* env
+ *   tsx scripts/upload-memo-posts-to-d1.ts --dry-run   # extract + log only
+ */
+
+import path from 'path';
+import { execSync } from 'child_process';
+import { extractMemoPosts, type MemoPostRow } from './extract-memo-posts';
+import { createD1ClientFromEnv, type D1Client } from './d1-env-client';
+
+export const CREATE_MEMO_POSTS_TABLE_SQL = `CREATE TABLE IF NOT EXISTS memo_posts (
+  file_path TEXT PRIMARY KEY,
+  date TEXT,
+  title TEXT NOT NULL,
+  authors TEXT NOT NULL,
+  tags TEXT NOT NULL,
+  commit_sha TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+)`;
+
+// keyed by file_path: a re-run replaces each post's row instead of inserting
+// a duplicate, same idempotent shape as #303's content_rollups upsert.
+export const UPSERT_MEMO_POST_SQL = `INSERT INTO memo_posts
+  (file_path, date, title, authors, tags, commit_sha, updated_at)
+  VALUES (?, ?, ?, ?, ?, ?, ?)
+  ON CONFLICT(file_path) DO UPDATE SET
+    date = excluded.date,
+    title = excluded.title,
+    authors = excluded.authors,
+    tags = excluded.tags,
+    commit_sha = excluded.commit_sha,
+    updated_at = excluded.updated_at`;
+
+export async function uploadMemoPosts(
+  client: D1Client,
+  rows: MemoPostRow[],
+  opts: { commitSha: string; dryRun?: boolean },
+): Promise<number> {
+  if (opts.dryRun) {
+    console.log('[dry-run] would execute:\n', CREATE_MEMO_POSTS_TABLE_SQL);
+    console.log(`[dry-run] would upsert ${rows.length} memo_posts row(s)`);
+    return rows.length;
+  }
+
+  await client.execute(CREATE_MEMO_POSTS_TABLE_SQL);
+  const updatedAt = new Date().toISOString();
+  for (const row of rows) {
+    await client.execute(UPSERT_MEMO_POST_SQL, [
+      row.filePath,
+      row.date,
+      row.title,
+      JSON.stringify(row.authors),
+      JSON.stringify(row.tags),
+      opts.commitSha,
+      updatedAt,
+    ]);
+  }
+  return rows.length;
+}
+
+async function main() {
+  const dryRun = process.argv.includes('--dry-run');
+  const commitSha =
+    process.env.GITHUB_SHA?.trim() || execSync('git rev-parse HEAD').toString().trim();
+
+  const vaultPath = path.join(process.cwd(), 'db/vault.parquet');
+  const rows = await extractMemoPosts(vaultPath);
+  console.log(`Extracted ${rows.length} per-post row(s) from ${vaultPath}${dryRun ? ' [dry-run]' : ''}`);
+
+  const client: D1Client = dryRun
+    ? {
+        execute: async () => {
+          throw new Error('D1Client.execute should not be called in --dry-run');
+        },
+      }
+    : createD1ClientFromEnv();
+
+  const count = await uploadMemoPosts(client, rows, { commitSha, dryRun });
+  console.log(dryRun ? 'Dry-run complete.' : `Uploaded ${count} memo_posts row(s) to D1.`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch(error => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/scripts/upload-rollups-to-d1.ts
+++ b/scripts/upload-rollups-to-d1.ts
@@ -15,6 +15,9 @@
 
 import { execSync } from 'child_process';
 import { collectVaultMetrics } from './monitor-vault-parquet';
+import { createD1ClientFromEnv, type D1Client } from './d1-env-client';
+
+export type { D1Client };
 
 export interface ContentRollup {
   commitSha: string;
@@ -35,10 +38,6 @@ export async function computeRollup(commitSha: string): Promise<ContentRollup> {
     pinned: metrics.pinned,
     missingEmbeddings: metrics.missingEmbeddings,
   };
-}
-
-export interface D1Client {
-  execute(sql: string, params?: unknown[]): Promise<unknown>;
 }
 
 export const CREATE_ROLLUP_TABLE_SQL = `CREATE TABLE IF NOT EXISTS content_rollups (
@@ -81,39 +80,6 @@ export async function uploadRollup(
     rollup.pinned,
     rollup.missingEmbeddings,
   ]);
-}
-
-function requireEnv(env: NodeJS.ProcessEnv, name: string): string {
-  const value = env[name];
-  if (!value) {
-    throw new Error(`Missing required env var: ${name}`);
-  }
-  return value;
-}
-
-function createD1ClientFromEnv(env: NodeJS.ProcessEnv = process.env): D1Client {
-  const accountId = requireEnv(env, 'D1_ACCOUNT_ID');
-  const databaseId = requireEnv(env, 'D1_DATABASE_ID');
-  const apiToken = requireEnv(env, 'D1_API_TOKEN');
-  const url = `https://api.cloudflare.com/client/v4/accounts/${accountId}/d1/database/${databaseId}/query`;
-
-  return {
-    async execute(sql, params = []) {
-      const res = await fetch(url, {
-        method: 'POST',
-        headers: {
-          authorization: `Bearer ${apiToken}`,
-          'content-type': 'application/json',
-        },
-        body: JSON.stringify({ sql, params }),
-      });
-      const json: any = await res.json().catch(() => ({}));
-      if (!res.ok || json?.success === false) {
-        throw new Error(`D1 query failed: ${res.status} ${JSON.stringify(json?.errors ?? json)}`);
-      }
-      return json;
-    },
-  };
 }
 
 async function main() {

--- a/scripts/upload-to-r2.ts
+++ b/scripts/upload-to-r2.ts
@@ -6,7 +6,11 @@
  * Artifact list is the exact set named in the #302 build-inventory
  * (docs/cf-migration/build-inventory.md): db/vault.parquet (carries the
  * embeddings), the search index, and the rendered `out/` tree. No other
- * paths are invented here.
+ * paths are invented here. One more object is generated (not scanned off
+ * disk): `posts.json`, the per-post rows extracted from db/vault.parquet by
+ * extract-memo-posts.ts -- the R2 twin of upload-memo-posts-to-d1.ts's
+ * memo_posts table (M4-05b, completing the DuckDB-kill M4-06 found
+ * unfinished in the aggregate-only content_rollups this script also feeds).
  *
  * Each file is uploaded to two keys so a re-run never duplicates objects:
  *   derived/<commitSha>/<relKey>  - immutable, one object per commit
@@ -24,8 +28,9 @@ import fs from 'fs';
 import path from 'path';
 import crypto from 'crypto';
 import { execSync } from 'child_process';
+import { extractMemoPosts } from './extract-memo-posts';
 
-export type ArtifactKind = 'vault-db' | 'search-index' | 'rendered';
+export type ArtifactKind = 'vault-db' | 'search-index' | 'rendered' | 'memo-posts';
 
 export interface ArtifactSource {
   kind: ArtifactKind;
@@ -151,6 +156,45 @@ export interface UploadPlan {
   action: 'upload' | 'skip-unchanged' | 'dry-run';
 }
 
+// Shared upload-one-object logic (content-hash HEAD-before-PUT skip, two
+// keys per object) factored out so an in-memory buffer (e.g. the generated
+// posts.json below) can reuse it without a round-trip through the filesystem
+// the way resolveArtifacts's on-disk artifacts do.
+export async function uploadBuffer(
+  client: R2Client,
+  body: Buffer,
+  relKey: string,
+  kind: ArtifactKind,
+  opts: { commitSha: string; dryRun?: boolean },
+): Promise<UploadPlan[]> {
+  const sha256 = crypto.createHash('sha256').update(body).digest('hex');
+  const contentType = guessContentType(relKey);
+  const plans: UploadPlan[] = [];
+
+  const keys = [`derived/${opts.commitSha}/${relKey}`, `derived/latest/${relKey}`];
+
+  for (const key of keys) {
+    let action: UploadPlan['action'] = 'upload';
+
+    if (opts.dryRun) {
+      action = 'dry-run';
+    } else {
+      const existing = await client.headObject(key);
+      if (existing?.contentSha256 === sha256) {
+        action = 'skip-unchanged';
+      }
+    }
+
+    if (action === 'upload') {
+      await client.putObject(key, body, { contentType, contentSha256: sha256 });
+    }
+
+    plans.push({ key, relKey, kind, sizeBytes: body.length, sha256, action });
+  }
+
+  return plans;
+}
+
 export async function uploadArtifacts(
   client: R2Client,
   artifacts: ArtifactSource[],
@@ -160,39 +204,7 @@ export async function uploadArtifacts(
 
   for (const artifact of artifacts) {
     const body = fs.readFileSync(artifact.localPath);
-    const sha256 = crypto.createHash('sha256').update(body).digest('hex');
-    const contentType = guessContentType(artifact.relKey);
-
-    const keys = [
-      `derived/${opts.commitSha}/${artifact.relKey}`,
-      `derived/latest/${artifact.relKey}`,
-    ];
-
-    for (const key of keys) {
-      let action: UploadPlan['action'] = 'upload';
-
-      if (opts.dryRun) {
-        action = 'dry-run';
-      } else {
-        const existing = await client.headObject(key);
-        if (existing?.contentSha256 === sha256) {
-          action = 'skip-unchanged';
-        }
-      }
-
-      if (action === 'upload') {
-        await client.putObject(key, body, { contentType, contentSha256: sha256 });
-      }
-
-      plans.push({
-        key,
-        relKey: artifact.relKey,
-        kind: artifact.kind,
-        sizeBytes: body.length,
-        sha256,
-        action,
-      });
-    }
+    plans.push(...(await uploadBuffer(client, body, artifact.relKey, artifact.kind, opts)));
   }
 
   return plans;
@@ -345,6 +357,17 @@ async function main() {
     : createR2ClientFromEnv();
 
   const plans = await uploadArtifacts(client, found, { commitSha, dryRun });
+
+  // Per-post rows (memo_posts' R2 twin): derived from db/vault.parquet, not
+  // an on-disk build artifact, so it goes through uploadBuffer directly
+  // rather than resolveArtifacts/uploadArtifacts's file-scan path.
+  const posts = await extractMemoPosts(path.join(repoRoot, 'db/vault.parquet'));
+  const postsBody = Buffer.from(JSON.stringify(posts, null, 2));
+  const postsPlans = await uploadBuffer(client, postsBody, 'posts.json', 'memo-posts', {
+    commitSha,
+    dryRun,
+  });
+  plans.push(...postsPlans);
 
   for (const plan of plans) {
     console.log(

--- a/test/extract-memo-posts.test.ts
+++ b/test/extract-memo-posts.test.ts
@@ -1,0 +1,63 @@
+/**
+ * @file extract-memo-posts.test.ts
+ * @description Extracts per-post rows from the REAL db/vault.parquet (same
+ * DuckDB approach #303 used for its rollup query) and checks the shape
+ * matches EXACTLY what fortress-api's discord.go reads off this file
+ * (date, title, authors, tags, file_path -- cross-checked against
+ * getMemosFromParquet / resolveAuthorsFromParquetByTitle in
+ * fortress-api/pkg/handler/discord/discord.go).
+ */
+
+import path from 'path';
+import { describe, test, expect } from 'vitest';
+import { extractMemoPosts } from '../scripts/extract-memo-posts';
+
+const vaultPath = path.join(process.cwd(), 'db/vault.parquet');
+
+describe('extractMemoPosts (real db/vault.parquet)', () => {
+  test('returns per-post rows shaped for fortress discord.go: file_path/date/title/authors/tags', async () => {
+    const rows = await extractMemoPosts(vaultPath);
+
+    expect(rows.length).toBeGreaterThan(1000);
+
+    for (const row of rows) {
+      expect(typeof row.filePath).toBe('string');
+      expect(row.filePath.length).toBeGreaterThan(0);
+      expect(typeof row.title).toBe('string');
+      expect(row.title.length).toBeGreaterThan(0);
+      expect(Array.isArray(row.authors)).toBe(true);
+      expect(Array.isArray(row.tags)).toBe(true);
+      expect(row.date === null || typeof row.date === 'string').toBe(true);
+      if (row.date !== null) {
+        expect(row.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      }
+    }
+  });
+
+  test('drops rows with no title or no file_path (not real posts)', async () => {
+    const rows = await extractMemoPosts(vaultPath);
+
+    expect(rows.every(r => r.filePath !== '' && r.title !== '')).toBe(true);
+  });
+
+  test('a known real post resolves with real authors/tags (matches the committed vault)', async () => {
+    const rows = await extractMemoPosts(vaultPath);
+    const post = rows.find(r => r.filePath === 'consulting/navigate/social-proof.md');
+
+    expect(post).toBeDefined();
+    expect(post?.title).toBe('Social proof');
+    expect(post?.authors).toEqual(['monotykamary']);
+    expect(post?.tags).toEqual(
+      expect.arrayContaining(['consulting', 'navigate', 'sales', 'social-proof']),
+    );
+    expect(post?.date).toBe('2025-09-08');
+  });
+
+  test('is stably ordered by file_path (deterministic re-runs)', async () => {
+    const rows = await extractMemoPosts(vaultPath);
+    const filePaths = rows.map(r => r.filePath);
+    const sorted = [...filePaths].sort();
+
+    expect(filePaths).toEqual(sorted);
+  });
+});

--- a/test/upload-memo-posts-to-d1.test.ts
+++ b/test/upload-memo-posts-to-d1.test.ts
@@ -1,0 +1,96 @@
+/**
+ * @file upload-memo-posts-to-d1.test.ts
+ * @description Unit tests against a mocked D1 client for
+ * scripts/upload-memo-posts-to-d1.ts (M4-05b, per-post rows completing the
+ * DuckDB-kill that #303's aggregate-only content_rollups left unfinished).
+ */
+
+import { describe, test, expect } from 'vitest';
+import {
+  uploadMemoPosts,
+  CREATE_MEMO_POSTS_TABLE_SQL,
+  UPSERT_MEMO_POST_SQL,
+} from '../scripts/upload-memo-posts-to-d1';
+import type { D1Client } from '../scripts/d1-env-client';
+import type { MemoPostRow } from '../scripts/extract-memo-posts';
+
+const samplePosts: MemoPostRow[] = [
+  {
+    filePath: 'consulting/navigate/social-proof.md',
+    date: '2025-09-08',
+    title: 'Social proof',
+    authors: ['monotykamary'],
+    tags: ['consulting', 'navigate', 'sales', 'social-proof'],
+  },
+  {
+    filePath: 'research/breakdown/cap.md',
+    date: '2025-09-09',
+    title: 'CAP breakdown',
+    authors: ['R-Jim'],
+    tags: ['architecture', 'audio', 'breakdown', 'screen-recording'],
+  },
+];
+
+function createRecordingD1Client(): { client: D1Client; calls: Array<{ sql: string; params?: unknown[] }> } {
+  const calls: Array<{ sql: string; params?: unknown[] }> = [];
+  const client: D1Client = {
+    async execute(sql, params) {
+      calls.push({ sql, params });
+      return { success: true };
+    },
+  };
+  return { client, calls };
+}
+
+describe('uploadMemoPosts', () => {
+  test('creates the table then upserts one row per post, keyed by file_path', async () => {
+    const { client, calls } = createRecordingD1Client();
+
+    const count = await uploadMemoPosts(client, samplePosts, { commitSha: 'deadbeef' });
+
+    expect(count).toBe(2);
+    expect(calls[0].sql).toBe(CREATE_MEMO_POSTS_TABLE_SQL);
+    const upserts = calls.filter(c => c.sql === UPSERT_MEMO_POST_SQL);
+    expect(upserts).toHaveLength(2);
+
+    const first = upserts[0].params!;
+    expect(first[0]).toBe('consulting/navigate/social-proof.md');
+    expect(first[1]).toBe('2025-09-08');
+    expect(first[2]).toBe('Social proof');
+    expect(JSON.parse(first[3] as string)).toEqual(['monotykamary']);
+    expect(JSON.parse(first[4] as string)).toEqual([
+      'consulting',
+      'navigate',
+      'sales',
+      'social-proof',
+    ]);
+    expect(first[5]).toBe('deadbeef');
+    expect(UPSERT_MEMO_POST_SQL).toMatch(/ON CONFLICT\(file_path\) DO UPDATE/);
+  });
+
+  test('a re-run for the same posts replaces each row (idempotent, no new PK)', async () => {
+    const { client, calls } = createRecordingD1Client();
+
+    await uploadMemoPosts(client, samplePosts, { commitSha: 'deadbeef' });
+    await uploadMemoPosts(client, samplePosts, { commitSha: 'cafef00d' });
+
+    const upserts = calls.filter(c => c.sql === UPSERT_MEMO_POST_SQL);
+    expect(upserts).toHaveLength(4);
+    // same file_path (PK) both runs, only commit_sha/updated_at differ
+    expect(upserts[0].params?.[0]).toBe(upserts[2].params?.[0]);
+    expect(upserts[0].params?.[5]).toBe('deadbeef');
+    expect(upserts[2].params?.[5]).toBe('cafef00d');
+  });
+
+  test('dry-run never touches the client (asserts against a client that throws if called)', async () => {
+    const throwingClient: D1Client = {
+      execute: async () => {
+        throw new Error('execute must not be called during dry-run');
+      },
+    };
+
+    await expect(
+      uploadMemoPosts(throwingClient, samplePosts, { commitSha: 'deadbeef', dryRun: true }),
+    ).resolves.toBe(samplePosts.length);
+  });
+});

--- a/test/upload-to-r2.test.ts
+++ b/test/upload-to-r2.test.ts
@@ -10,7 +10,7 @@ import os from 'os';
 import path from 'path';
 import crypto from 'crypto';
 import { describe, test, expect, beforeEach, afterEach } from 'vitest';
-import { resolveArtifacts, uploadArtifacts, type R2Client } from '../scripts/upload-to-r2';
+import { resolveArtifacts, uploadArtifacts, uploadBuffer, type R2Client } from '../scripts/upload-to-r2';
 
 let repoRoot: string;
 
@@ -175,5 +175,80 @@ describe('uploadArtifacts', () => {
 
     expect(plans.every(p => p.action === 'dry-run')).toBe(true);
     expect(plans).toHaveLength(found.length * 2);
+  });
+});
+
+// posts.json (M4-05b): a generated in-memory object, not scanned off disk
+// like the #302 artifacts above, so it goes through uploadBuffer directly
+// (the same content-hash HEAD-before-PUT logic uploadArtifacts uses per file).
+describe('uploadBuffer (posts.json, the memo_posts R2 twin)', () => {
+  function createRecordingClient(existingShaByKey: Record<string, string> = {}): {
+    client: R2Client;
+    puts: Array<{ key: string; body: Buffer; contentType: string; contentSha256: string }>;
+  } {
+    const puts: Array<{ key: string; body: Buffer; contentType: string; contentSha256: string }> = [];
+    const client: R2Client = {
+      async headObject(key) {
+        const sha = existingShaByKey[key];
+        return sha ? { contentSha256: sha } : null;
+      },
+      async putObject(key, body, opts) {
+        puts.push({ key, body, ...opts });
+      },
+    };
+    return { client, puts };
+  }
+
+  const samplePostsJson = Buffer.from(
+    JSON.stringify([
+      { filePath: 'consulting/navigate/social-proof.md', date: '2025-09-08', title: 'Social proof', authors: ['monotykamary'], tags: ['consulting'] },
+    ]),
+  );
+
+  test('uploads posts.json to a commit-scoped key and a latest key, as JSON content-type', async () => {
+    const { client, puts } = createRecordingClient();
+
+    const plans = await uploadBuffer(client, samplePostsJson, 'posts.json', 'memo-posts', {
+      commitSha: 'abc1234',
+    });
+
+    expect(plans.map(p => p.key).sort()).toEqual(
+      ['derived/abc1234/posts.json', 'derived/latest/posts.json'].sort(),
+    );
+    expect(plans.every(p => p.action === 'upload')).toBe(true);
+    expect(puts.every(p => p.contentType === 'application/json')).toBe(true);
+  });
+
+  test('is idempotent: unchanged posts.json content skips the write', async () => {
+    const sha256 = crypto.createHash('sha256').update(samplePostsJson).digest('hex');
+    const { client, puts } = createRecordingClient({
+      'derived/abc1234/posts.json': sha256,
+      'derived/latest/posts.json': sha256,
+    });
+
+    const plans = await uploadBuffer(client, samplePostsJson, 'posts.json', 'memo-posts', {
+      commitSha: 'abc1234',
+    });
+
+    expect(plans.every(p => p.action === 'skip-unchanged')).toBe(true);
+    expect(puts).toHaveLength(0);
+  });
+
+  test('dry-run never touches the client', async () => {
+    const throwingClient: R2Client = {
+      headObject: async () => {
+        throw new Error('headObject must not be called during dry-run');
+      },
+      putObject: async () => {
+        throw new Error('putObject must not be called during dry-run');
+      },
+    };
+
+    const plans = await uploadBuffer(throwingClient, samplePostsJson, 'posts.json', 'memo-posts', {
+      commitSha: 'abc1234',
+      dryRun: true,
+    });
+
+    expect(plans.every(p => p.action === 'dry-run')).toBe(true);
   });
 });


### PR DESCRIPTION
## Outcome

Completes the DuckDB-kill that M4-06 found unfinished: #303's export produced
only the AGGREGATE `content_rollups` D1 table, but fortress-api's real
DuckDB queries (`getMemosFromParquet` / `resolveAuthorsFromParquetByTitle` in
`fortress-api/pkg/handler/discord/discord.go`) need PER-POST rows. This adds
a `memo_posts` D1 table (keyed by `file_path`, idempotent upsert) and a
`derived/latest/posts.json` R2 object, both extracted from `db/vault.parquet`
via DuckDB (same approach #303 used for its rollup).

## Columns, matched to discord.go

`getMemosFromParquet` reads `date`, `title`, `authors`, `tags`, `file_path`
(+ `content`) off the parquet row map; `resolveAuthorsFromParquetByTitle`
reads `title`/`authors`. `memo_posts` carries exactly `file_path` (PK),
`date`, `title`, `authors` (JSON array), `tags` (JSON array).

`content` is deliberately NOT carried: discord.go reads `row["content"]`,
but `db/vault.parquet`'s real schema has no `content` column (only
`md_content`) -- confirmed via `DESCRIBE SELECT * FROM 'db/vault.parquet'`
-- so that read always misses in production today. Not reproduced here.

## Verify

- `scripts/extract-memo-posts.ts`: DuckDB query against the real
  `db/vault.parquet` (1654 real per-post rows out of 2031 total rows once
  non-post rows without title/file_path are dropped).
- `test/extract-memo-posts.test.ts`: runs against the REAL committed
  `db/vault.parquet` (not a fixture) -- shape assertions + a golden-row
  check against a known real post.
- `test/upload-memo-posts-to-d1.test.ts`: mocked D1 client asserting the
  `CREATE TABLE` + per-post `ON CONFLICT(file_path) DO UPDATE` upserts,
  idempotent re-run, dry-run-never-touches-client.
- `test/upload-to-r2.test.ts` (extended): `uploadBuffer` (new shared helper,
  factored out of `uploadArtifacts`) asserting the `posts.json` two-key
  upload + content-hash skip-unchanged idempotency.
- `65/65` vitest tests pass (`pnpm exec vitest run`), including the 3
  pre-existing suites (no regressions).

## Fingerprint (deliberately out of scope here)

- **Live upload**: deploy-gated, reuses M4-05's 7 secrets
  (`R2_ACCOUNT_ID`/`R2_BUCKET_NAME`/`R2_ACCESS_KEY_ID`/`R2_SECRET_ACCESS_KEY`/
  `D1_ACCOUNT_ID`/`D1_DATABASE_ID`/`D1_API_TOKEN`) + a new `memo_posts` table.
- **Paired follow-up**: widen `D1MemoAnalyticsReader` in foundation-workers'
  `packages/shared` to serve `memo_posts` -- a separate `foundation-workers`
  PR, not this one.

## Roadmap

`dfoundation` `projects/cloudflare-migration/megagoals/memo-track/ROADMAP.md`
(05b row added).
