### PR TITLE
feat(cf-migration): TypeScript rewrite of Elixir export_markdown compiler (100% byte-parity)

### DIFF
--- a/docs/cf-migration/compiler-rewrite.md
+++ b/docs/cf-migration/compiler-rewrite.md
@@ -1,0 +1,147 @@
+# CF-N.2: Elixir `export_markdown` -> TypeScript rewrite
+
+Design note + parity report for the real CF-N.2 sub-goal: rewrite the Elixir
+`mix export_markdown` content-compilation step (`lib/obsidian-compiler/`) as TypeScript so
+the memo.d.foundation build is one stack (TS in GitHub Actions), byte-comparable to the
+Elixir output. Produced by porting the code and then running BOTH compilers against the
+same real `vault` snapshot and diffing `public/content/`, not by reading code cold.
+
+The Elixir compiler is **retained** as the oracle + fallback. Swapping the build to call
+the TS version (editing the `Makefile` / `Dockerfile` / CI) is a later step, not this one.
+
+## The half this rewrites (and the half already done)
+
+Per the merged `build-inventory.md` (CF-N.3): the DOWNSTREAM artifact layer
+(`scripts/memo-build.ts` + `generate-*.ts` + `next build`) is already TypeScript. The
+UPSTREAM half, the vault -> `public/content` markdown compilation, was still Elixir. That
+upstream half is what this sub-goal ports.
+
+```
+vault/ (Obsidian markdown, git submodule dwarvesf/brainery)
+   |
+   |  ==> WAS: mix export_markdown  (Elixir, lib/obsidian-compiler)
+   |  ==> NOW: tsx scripts/export-markdown.ts  (TypeScript, this sub-goal)
+   v
+public/content/**/*.md (+ assets, + copied db/*.parquet)
+   |
+   |  scripts/memo-build.ts + generate-*.ts + next build  (already TypeScript, CF-N.3)
+   v
+site artifacts (menu/search/backlinks/redirects JSON, out/ static HTML, RSS)
+```
+
+Out of scope (unchanged, still Elixir): `mix duckdb.export` (regenerates `db/vault.parquet`
+rows + embeddings from source; needs paid embedding providers; run only by manual
+`workflow_dispatch`). That is a separate DuckDB/embeddings pipeline, not the markdown
+compiler, and the inventory already documented its freshness/automation gap.
+
+## The Elixir pipeline, mapped to the TS port
+
+Source of truth: `lib/obsidian-compiler/lib/memo/export_markdown.ex` +
+`lib/memo/common/{slugify,link_utils,katex_utils,frontmatter,file_utils,duckdb_utils}.ex`.
+Every function below is ported in `scripts/export-markdown.ts`.
+
+| Stage | Elixir | TS port | Notes |
+| --- | --- | --- | --- |
+| List vault files | `FileUtils.list_files_recursive` | `listFilesRecursive` | DFS, dirs + files |
+| Ignore filter | `FileUtils.ignored?` + `.export-ignore` | `ignored` + `readExportIgnoreFile` | same `dir/`, `*suffix`, `prefix*`, exact-match pattern semantics |
+| Frontmatter gate | `Frontmatter.contains_required_frontmatter_keys?` | `containsRequiredFrontmatterKeys` | requires `title`+`description` (or `skip_frontmatter_check: true`); `authors`/`tags` must be lists; handles a list-of-maps frontmatter |
+| Per-file content pipeline (below) | `process_file` | `processFileContent` | run in order |
+| 1. Extract wikilinks | `LinkUtils.extract_links` | `extractLinks` | **arity-drop parity, see below** |
+| 2. Resolve links | `LinkUtils.resolve_links` | `resolveLinks` | fuzzy: basename substring match, last-in-order wins |
+| 3. Convert links | `LinkUtils.convert_links` | `convertLinks` | 4 ordered passes (with-alt, without-alt, embedded-image, markdown-link), skipping fenced code blocks |
+| 4. `dsql` blocks | `process_duckdb_queries` -> `DuckDBUtils` | `processDuckdbQueries` | shells to the `duckdb` CLI (same `IMPORT DATABASE` + `markdown_link` TEMP MACRO + `-json` args); renders `dsql-table`/`dsql-list` to markdown |
+| 5. Slugify md links | `Slugify.slugify_markdown_links` | `slugifyMarkdownLinks` | code-block-aware |
+| 6. Wrap multiline KaTeX | `KatexUtils.wrap_multiline_katex` | `wrapMultilineKatex` | `$$...$$` with a newline -> padded with `\n` |
+| Export path + slug | `replace_path_prefix` + `preserve_relative_prefix_and_slugify` | `replacePathPrefix` + `preserveRelativePrefixAndSlugify` | `.mdx` files keep their name unslugified; `home.md`/`index.md` at root are skipped |
+| Assets + db copy | `export_assets_folder` + `export_db_directory` | (see Scope edges) | not ported: byte-identical file copies, no transform |
+
+### The one real parity bug the port had to reproduce
+
+Elixir's `extract_links` returns a link only for three wikilink shapes: image embeds
+`![[...]]`, the `.md` path of `[[x.md|alt]]`, and the file of `[[x|alt]]`. It does **not**
+extract plain `[[x]]` or `[[x.md]]`. This is not by design, it is an emergent artifact:
+the `flat_map` clauses pattern-match on the **arity** of each `Regex.scan` result list
+(`[_, image]`, `[_, _, pre, _]`, `[_, _, _, _, file, _]`), and Elixir's `Regex.scan` drops
+trailing non-participating capture groups. A plain `[[x]]` matches the 7th alternative, so
+its result list has 8 elements and lands on none of the 2/4/6-arity clauses; it is silently
+dropped. `[[x.md]]` (group 6, 7-elem list) is dropped the same way.
+
+The first cut of the port faithfully extracted plain `[[x]]`, which is the "obvious" reading
+of the regex. That over-populated the fuzzy resolver: a plain `[[Go]]` or `[[1]]` was
+resolved by naive basename-substring matching (`"go"` is a substring of `argocd.md`,
+`remote-...going...webp`, etc.), so the port emitted a different (still broken) link target
+than Elixir, which fell through to its fallback. Matching Elixir's arity-drop behavior, i.e.
+**not** extracting plain `[[x]]`/`[[x.md]]`, closed the gap to 100%.
+
+The resolved links in those degenerate cases are broken in BOTH outputs (`[alt]()` with an
+empty target, because the fuzzy match does not point at a real reachable file); only the
+dead link's alt text differed. Parity here means reproducing the Elixir behavior exactly,
+bug included, since the Elixir output is the oracle the downstream TS layer already consumes.
+
+## Parity method
+
+1. Check out the real `vault` submodule (`dwarvesf/brainery`, 568M, https override for the
+   SSH `.gitmodules` URL, same as the CF-N.3 validation).
+2. Run the Elixir oracle: `cd lib/obsidian-compiler && mix export_markdown --vault ../../vault --output ../../public/content` (local Elixir 1.18/OTP26, `mix deps.get && mix compile`).
+3. Run the TS port to a parallel dir: `tsx scripts/export-markdown.ts --vault ../../vault --output ../../ts-content --db ../../db` (deps borrowed read-only from a sibling `node_modules`; no install in the worktree).
+4. Diff the two `*.md`/`*.mdx` trees: file-set comparison + byte comparison of every common file.
+
+## Measured parity
+
+Real vault snapshot (`dwarvesf/brainery`, 687 source `.md` files):
+
+| Metric | Result |
+| --- | --- |
+| Files emitted (Elixir) | 655 (`.md` + `.mdx`) |
+| Files emitted (TS) | 655 |
+| Files only in Elixir output | 0 |
+| Files only in TS output | 0 |
+| Common files | 655 |
+| **Byte-identical** | **655 / 655** |
+| **Byte-parity** | **100.00%** |
+
+The 687 -> 655 reduction (Elixir and TS identically) is the frontmatter gate + `.export-ignore`
++ root `home.md`/`index.md` skip removing files that do not export.
+
+Determinism: the Elixir oracle is deterministic run-to-run (verified: a second full export
+produced a 0-file self-diff). The TS port uses Node's deterministic sorted directory order.
+Because the arity-drop fix removes the only links that fed the order-sensitive fuzzy resolver
+on ambiguous short keys, the port is order-independent in practice and matches the oracle
+under normal (sorted) traversal, no order-pinning needed. A debug hook (`N2_ORDER_FILE`) can
+pin the traversal order for future re-verification.
+
+## Scope edges (the honest gap list)
+
+None of these block the 100% markdown byte-parity above; they are the parts of the Elixir
+task deliberately not carried into the content port, with why.
+
+| Item | Ported? | Why |
+| --- | --- | --- |
+| Per-file markdown transforms (links, slugs, dsql, katex, frontmatter gate, ignore, path/slug) | **Yes** | the actual compiler; 100% byte-parity |
+| Asset-folder copy (`export_assets_folder`) | No | byte-identical file copies, no transform; a plain recursive copy with slugified names. Trivial to add; excluded from the content diff because it is not a content transform. |
+| `db/` directory copy (`export_db_directory`) | No | same, a copy of the git-committed parquet artifacts into `public/content/db/`. |
+| Incremental cache (`.memo_export_cache.json`) | No | a re-run optimization (size/mtime/md5 skip). A clean CI build processes every file, so the cache changes nothing about the OUTPUT. Omitting it keeps the port simple; a full rebuild is the CI norm anyway. |
+| `mix duckdb.export` (parquet + embeddings regen) | No (out of scope) | a separate DuckDB/embeddings pipeline, not the markdown compiler; needs paid embedding providers; run only by manual `workflow_dispatch`. Its gap was already named in `build-inventory.md`. |
+| Verbose `IO.puts` progress lines | No | stdout debug noise, not part of the on-disk output being compared. |
+
+## What is NOT done (deliberately, this is a later step)
+
+- The build is **not** switched over. `Makefile`, `Dockerfile`, and CI still call
+  `mix export_markdown`. The Elixir compiler stays as the oracle + fallback until the TS
+  version is wired in and burned in.
+- Assets/db copy + a thin `Makefile`/CI switch are the remaining work to fully retire the
+  Elixir markdown step. They are mechanical (copies + a one-line target change), gated on
+  someone choosing to flip the build.
+
+## Reproduce
+
+```
+# oracle
+cd lib/obsidian-compiler && mix deps.get && mix compile
+mix export_markdown --vault ../../vault --output ../../public/content
+# port
+cd .. && tsx scripts/export-markdown.ts --vault vault --output ts-content --db db
+# diff *.md/*.mdx trees, byte-compare every common file  (expect 655/655 identical)
+# unit guards
+pnpm exec vitest run test/export-markdown.test.ts
+```

--- a/scripts/export-markdown.ts
+++ b/scripts/export-markdown.ts
@@ -1,0 +1,644 @@
+/**
+ * export-markdown.ts, TypeScript port of the Elixir `mix export_markdown` step
+ * (lib/obsidian-compiler, Memo.ExportMarkdown + Common.{Slugify,LinkUtils,KatexUtils,
+ * Frontmatter,FileUtils,DuckDBUtils}).
+ *
+ * CF-N.2: collapse the build to one stack (TS in GitHub Actions). The Elixir compiler
+ * stays as the oracle/fallback until this reaches parity + is deployed (a later step).
+ *
+ * This is a FAITHFUL port of the per-file content pipeline, aiming for byte-parity with
+ * the Elixir output. Deliberate scope edges are marked `PARITY:` inline and collected in
+ * docs/cf-migration/compiler-rewrite.md. Notably the incremental cache is intentionally
+ * NOT ported (a clean run processes every file; the cache only affects re-runs), and the
+ * verbose IO.puts debug lines the Elixir emits to stdout are not reproduced (they are not
+ * part of the on-disk output being compared).
+ *
+ * Usage:
+ *   tsx scripts/export-markdown.ts [--vault ../../vault] [--output ../../public/content]
+ * (paths default to the same values the Elixir Mix task uses, relative to
+ * lib/obsidian-compiler; when run from repo root pass --vault vault --output public/content)
+ */
+import * as fs from "fs";
+import * as fsp from "fs/promises";
+import * as nodePath from "path";
+import { execFileSync } from "child_process";
+import { createHash } from "crypto";
+
+const P = nodePath.posix;
+
+// ---------------------------------------------------------------------------
+// Slugify (port of Memo.Common.Slugify)
+// ---------------------------------------------------------------------------
+
+export function slugify(str: string): string {
+  return str
+    .toLowerCase()
+    .replace(/[^a-z0-9\s_-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, ""); // String.trim("-")
+}
+
+function extname(file: string): string {
+  const base = P.basename(file);
+  const dot = base.lastIndexOf(".");
+  // Elixir Path.extname returns "" when the dot is at position 0 (dotfile) or absent.
+  if (dot <= 0) return "";
+  return base.slice(dot);
+}
+
+function rootname(file: string): string {
+  const ext = extname(file);
+  return ext ? file.slice(0, file.length - ext.length) : file;
+}
+
+export function slugifyFilename(filename: string): string {
+  const base = P.basename(filename);
+  const name = rootname(base);
+  const ext = extname(filename);
+  return slugify(name) + ext;
+}
+
+// Elixir Path.dirname("file") === "." ; Path.split(".") === ["."] ; Path.join(["",...]) trims.
+function elixirDirname(path: string): string {
+  const d = P.dirname(path);
+  return d;
+}
+
+function slugifyDirectory(path: string): string {
+  const parts = path.split("/").filter((s) => s !== "");
+  const mapped = parts.map(slugify).filter((s) => s !== "");
+  return mapped.join("/");
+}
+
+export function slugifyPath(path: string): string {
+  const dirname = elixirDirname(path);
+  const basename = P.basename(path);
+  const dir = slugifyDirectory(dirname);
+  const file = slugifyFilename(basename);
+  return dir ? `${dir}/${file}` : file;
+}
+
+function slugifyPathComponents(path: string): string {
+  return path
+    .split("/")
+    .map((c) => {
+      if (c === "." || c === ".." || c === "/" || c === "") return c;
+      return slugifyFilename(c);
+    })
+    .filter((c, i, arr) => !(c === "" && i > 0 && i < arr.length)) // keep leading/trailing markers as Path.join would
+    .join("/");
+}
+
+export function slugifyLinkPath(link: string): string {
+  if (/^(https?:\/\/|#)/.test(link)) return link;
+  if (link.includes("#")) {
+    const idx = link.indexOf("#");
+    const path = link.slice(0, idx);
+    const fragment = link.slice(idx + 1);
+    const slugged = slugifyPathComponents(safeDecode(path));
+    return `${slugged}#${fragment}`;
+  }
+  return slugifyPathComponents(safeDecode(link));
+}
+
+function safeDecode(s: string): string {
+  try {
+    return decodeURIComponent(s);
+  } catch {
+    return s;
+  }
+}
+
+function splitContentAndCodeBlocks(content: string): Array<{ code: boolean; text: string }> {
+  // Regex.split(~r/(```[\s\S]*?```)/m, include_captures: true)
+  const re = /(```[\s\S]*?```)/g;
+  const out: Array<{ code: boolean; text: string }> = [];
+  let last = 0;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(content)) !== null) {
+    if (m.index > last) out.push({ code: false, text: content.slice(last, m.index) });
+    out.push({ code: true, text: m[0] });
+    last = m.index + m[0].length;
+  }
+  if (last < content.length) out.push({ code: false, text: content.slice(last) });
+  if (out.length === 0) out.push({ code: false, text: content });
+  return out;
+}
+
+export function slugifyMarkdownLinks(content: string): string {
+  return splitContentAndCodeBlocks(content)
+    .map((part) => (part.code ? part.text : slugifyLinksInText(part.text)))
+    .join("");
+}
+
+function slugifyLinksInText(text: string): string {
+  const re = /!?\[([^\]]*)\]\(([^)]+)\)/g;
+  return text.replace(re, (full, linkText, link) => {
+    const slugged = slugifyLinkPath(link);
+    return full.startsWith("!") ? `![${linkText}](${slugged})` : `[${linkText}](${slugged})`;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// KaTeX (port of Memo.Common.KatexUtils)
+// ---------------------------------------------------------------------------
+
+export function wrapMultilineKatex(content: string): string {
+  return content.replace(/\$\$([\s\S]*?)\$\$/gm, (_full, katex) =>
+    katex.includes("\n") ? `\n$$${katex}$$\n` : `$$${katex}$$`
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Frontmatter (port of Memo.Common.Frontmatter)
+// ---------------------------------------------------------------------------
+
+// gray-matter/js-yaml are borrowed from the parent node_modules.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const yaml = require("js-yaml");
+
+function parseFrontmatter(content: string): any | null {
+  // ~r/^---\n(.*?)\n---/s
+  const m = /^---\n([\s\S]*?)\n---/.exec(content);
+  if (!m) return null;
+  try {
+    return yaml.load(m[1]);
+  } catch {
+    return null;
+  }
+}
+
+function hasRequiredFields(fm: any): boolean {
+  return fm && typeof fm === "object" && "title" in fm && "description" in fm;
+}
+
+function hasValidOptionalFields(fm: any): boolean {
+  const authors = fm.authors;
+  const tags = fm.tags;
+  return (
+    (authors === undefined || authors === null || Array.isArray(authors)) &&
+    (tags === undefined || tags === null || Array.isArray(tags))
+  );
+}
+
+export function containsRequiredFrontmatterKeys(file: string): boolean {
+  let content: string;
+  try {
+    content = fs.readFileSync(file, "utf8");
+  } catch {
+    return false;
+  }
+  const fm = parseFrontmatter(content);
+  if (fm === null || fm === undefined) return false;
+  if (fm && typeof fm === "object" && !Array.isArray(fm)) {
+    if (fm.skip_frontmatter_check === true) return true;
+    return hasRequiredFields(fm) && hasValidOptionalFields(fm);
+  }
+  if (Array.isArray(fm)) {
+    return fm.some(
+      (item) =>
+        item &&
+        typeof item === "object" &&
+        (item.skip_frontmatter_check === true ||
+          (hasRequiredFields(item) && hasValidOptionalFields(item)))
+    );
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// FileUtils (port of Memo.Common.FileUtils)
+// ---------------------------------------------------------------------------
+
+function normalizePath(path: string): string {
+  // The Elixir version replaces a mojibake sequence then round-trips codepoints < 128
+  // unchanged and codepoints >= 128 unchanged too, i.e. it is effectively identity apart
+  // from the "Â§" -> "§" fix. We replicate exactly that.
+  return path.replace(/Â§/g, "§");
+}
+
+export function listFilesRecursive(dir: string): string[] {
+  const out: string[] = [];
+  const entries = fs.readdirSync(dir);
+  for (const file of entries) {
+    const normalized = normalizePath(file);
+    const full = P.join(dir, normalized);
+    let isDir = false;
+    try {
+      isDir = fs.statSync(full).isDirectory();
+    } catch {
+      isDir = false;
+    }
+    if (isDir) {
+      out.push(full, ...listFilesRecursive(full));
+    } else {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function readExportIgnoreFile(ignoreFile: string): string[] {
+  if (!fs.existsSync(ignoreFile)) return [];
+  return fs
+    .readFileSync(ignoreFile, "utf8")
+    .split("\n")
+    .map((l) => l.replace(/\r$/, ""))
+    .filter((l) => l !== "" && !l.startsWith("#"));
+}
+
+function matchPattern(path: string, pattern: string): boolean {
+  if (pattern.endsWith("/")) {
+    return path.startsWith(pattern) || path.includes(`/${pattern}`);
+  }
+  if (pattern.startsWith("*")) {
+    return path.endsWith(pattern.replace(/^\*+/, ""));
+  }
+  if (pattern.endsWith("*")) {
+    return path.startsWith(pattern.replace(/\*+$/, ""));
+  }
+  return path === pattern;
+}
+
+function ignored(file: string, patterns: string[], vaultpath: string): boolean {
+  const rel = P.relative(vaultpath, file);
+  const normalized = normalizePath(rel);
+  return patterns.some((p) => matchPattern(normalized, p));
+}
+
+// ---------------------------------------------------------------------------
+// LinkUtils (port of Memo.Common.LinkUtils)
+// ---------------------------------------------------------------------------
+
+const EXTRACT_RE =
+  /!\[\[((?:[^\]]|\.mp4|\.webp|\.png|\.jpg|\.gif|\.svg)+)\]\]|\[\[([^\|\]]+\.md)\|([^\]]+)\]\]|\[\[([^\|\]]+)\|([^\]]+)\]\]|\[\[([^\|\]]+\.md)\]\]|\[\[([^\]]+)\]\]/g;
+
+export function extractLinks(content: string): string[] {
+  const links: string[] = [];
+  let m: RegExpExecArray | null;
+  EXTRACT_RE.lastIndex = 0;
+  while ((m = EXTRACT_RE.exec(content)) !== null) {
+    // Mirror the Elixir flat_map clause ordering (first non-nil group wins).
+    if (m[1] !== undefined) links.push(m[1]); // image embed
+    else if (m[3] !== undefined) links.push(m[2]); // [[x.md|alt]] -> pre (the path)
+    else if (m[5] !== undefined) links.push(m[4]); // [[x|alt]] -> file
+    else if (m[6] !== undefined) links.push(m[6]); // [[x.md]]
+    else if (m[7] !== undefined) links.push(m[7]); // [[x]]
+  }
+  return links;
+}
+
+/**
+ * resolve_links: for each link, find files whose basename contains the link string (case
+ * variants). Later matches (in all_files order) overwrite earlier for the same link key, * we replicate `for ... into: %{}` (last write wins).
+ */
+export function resolveLinks(
+  links: string[],
+  allFiles: string[],
+  vaultpath: string
+): Map<string, string> {
+  const resolved = new Map<string, string>();
+  for (const link of links) {
+    const downLink = link.toLowerCase();
+    for (const path of allFiles) {
+      const base = P.basename(path);
+      const downBase = base.toLowerCase();
+      if (base.includes(link) || downBase.includes(downLink)) {
+        resolved.set(link, P.relative(vaultpath, path).toLowerCase()); // last write wins
+      }
+    }
+  }
+  return resolved;
+}
+
+function removeIndexSuffix(path: string): string {
+  return path.replace(/_index\.md$/, ".md").replace(/_index$/, "");
+}
+
+function fileValid(link: string, currentFile: string): boolean {
+  // check_frontmatter=false variant (the only one used by convert_links).
+  const decoded = link.replace(/%20/g, " ");
+  const currentDir = P.dirname(currentFile);
+  const fullPath = P.join(currentDir, decoded);
+  const normalized = nodePath.resolve(fullPath);
+  if (fs.existsSync(normalized)) return true;
+  const filename = P.basename(decoded);
+  const lower = filename.toLowerCase();
+  if (["index.md", "readme.md", "index.mdx", "readme.mdx"].includes(lower)) {
+    return caseInsensitiveFileExists(currentDir, filename);
+  }
+  return false;
+}
+
+function caseInsensitiveFileExists(directory: string, target: string): boolean {
+  const lower = target.toLowerCase();
+  try {
+    return fs.readdirSync(directory).some((f) => f.toLowerCase() === lower);
+  } catch {
+    return false;
+  }
+}
+
+function buildLink(altText: string, resolvedPath: string, link: string, currentFile: string): string {
+  return fileValid(link, currentFile) ? `[${altText}](${resolvedPath})` : `[${altText}]()`;
+}
+
+export function convertLinks(
+  content: string,
+  resolvedLinks: Map<string, string>,
+  currentFile: string
+): string {
+  // sanitize: key `\|` -> `|`, value trailing `\` -> ""
+  const sanitized = new Map<string, string>();
+  for (const [k, v] of resolvedLinks) {
+    sanitized.set(k.replace(/\\\|/g, "|"), v.replace(/\\$/, ""));
+  }
+
+  return splitContentAndCodeBlocks(content)
+    .map((part) => {
+      if (part.code) return part.text;
+      let text = part.text;
+      text = convertLinksWithAltText(text, sanitized, currentFile);
+      text = convertLinksWithoutAltText(text, sanitized, currentFile);
+      text = convertEmbeddedImages(text, sanitized, currentFile);
+      text = convertMarkdownLinks(text, sanitized, currentFile);
+      return text;
+    })
+    .join("");
+}
+
+function convertLinksWithAltText(content: string, resolved: Map<string, string>, cur: string): string {
+  const re = /(?<![`\w])\[\[([^\|\]]+)\|([^\]]+)\]\](?![`\w])/g;
+  return content.replace(re, (_full, link, altText) => {
+    const resolvedPath = removeIndexSuffix(
+      slugifyLinkPath((resolved.get(link) ?? link).replace(/\\$/, ""))
+    );
+    return buildLink(altText, resolvedPath, link, cur);
+  });
+}
+
+function convertLinksWithoutAltText(content: string, resolved: Map<string, string>, cur: string): string {
+  const re = /(?![`\w])\[\[([^\]]+)\]\](?![`\w])/g;
+  return content.replace(re, (_full, link) => {
+    const resolvedPath = removeIndexSuffix(
+      slugifyLinkPath((resolved.get(link) ?? `${link}.md`).replace(/\\$/, ""))
+    );
+    const altText = P.basename(resolvedPath, ".md");
+    return buildLink(altText, resolvedPath, link, cur);
+  });
+}
+
+function convertEmbeddedImages(content: string, resolved: Map<string, string>, cur: string): string {
+  const re = /!\[\[([^\]]+)\]\]/g;
+  return content.replace(re, (_full, link) => {
+    const resolvedPath = slugifyLinkPath((resolved.get(link) ?? link).replace(/\\$/, ""));
+    return fileValid(link, cur) ? `![](${resolvedPath})` : `![]()`;
+  });
+}
+
+function convertMarkdownLinks(content: string, resolved: Map<string, string>, cur: string): string {
+  const re = /\[([^\]]+)\]\(([^)]+\.md)\)/g;
+  return content.replace(re, (_full, altText, link) => {
+    const resolvedPath = removeIndexSuffix(
+      slugifyLinkPath((resolved.get(link) ?? link).replace(/\\$/, ""))
+    );
+    return buildLink(altText, resolvedPath, link, cur);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// DuckDB dsql blocks (port of Memo.Common.DuckDBUtils, via the duckdb CLI)
+// ---------------------------------------------------------------------------
+
+const MACRO =
+  "CREATE OR REPLACE TEMP MACRO markdown_link(title, file_path) AS '[' || COALESCE(title, '/' || REGEXP_REPLACE(REGEXP_REPLACE(LOWER(REGEXP_REPLACE(REPLACE(REPLACE(file_path, '.md', ''), ' ', '-'),'[^a-zA-Z0-9/_-]+', '-')), '(-/|-$|_index$)', ''), '/readme$', '')) || '](/' || REGEXP_REPLACE(REGEXP_REPLACE(LOWER(REGEXP_REPLACE(REPLACE(REPLACE(file_path, '.md', ''), ' ', '-'),'[^a-zA-Z0-9/_-]+', '-')), '(-/|-$|_index$)', ''), '/readme$', '') || ')'";
+
+function duckdbQueryTemp(query: string, dbDir: string): { ok: boolean; data: any } {
+  try {
+    const out = execFileSync(
+      "duckdb",
+      ["-json", "-cmd", `IMPORT DATABASE '${dbDir}'`, "-cmd", MACRO, "-c", query],
+      { encoding: "utf8", maxBuffer: 256 * 1024 * 1024 }
+    );
+    if (out === "") return { ok: true, data: [] };
+    try {
+      return { ok: true, data: JSON.parse(out) };
+    } catch {
+      return { ok: true, data: out };
+    }
+  } catch (e: any) {
+    return { ok: false, data: e.stderr || e.message };
+  }
+}
+
+function extractHeadersFromQuery(query: string): string[] {
+  const m = /SELECT\s+([\s\S]+?)\s+FROM/i.exec(query);
+  if (!m) return [];
+  return m[1]
+    .split(",")
+    .map(extractColumnName)
+    .filter((c): c is string => c != null);
+}
+
+function cleanName(name: string): string {
+  return name.replace(/["\[\]`()]/g, "").trim();
+}
+
+function extractColumnName(column: string): string | null {
+  const col = column.trim();
+  let mm: RegExpExecArray | null;
+  if ((mm = /\sAS\s+'([^']+)'/i.exec(col))) return cleanName(mm[1]);
+  if ((mm = /\sAS\s+"([^"]+)"/i.exec(col))) return cleanName(mm[1]);
+  if (/\sAS\s/i.test(col)) {
+    const parts = col.split(/\sAS\s/i);
+    return cleanName(parts[parts.length - 1]);
+  }
+  if (/^[\w\d_]+\(.*\)\s+AS\s+\w+$/i.test(col)) {
+    mm = /^.*\)\s+AS\s+(\w+)$/i.exec(col);
+    return mm ? cleanName(mm[1]) : cleanName(col);
+  }
+  if (/^[\w\d_]+\(.*\)\s+\w+$/.test(col)) {
+    mm = /^.*\)\s+(\w+)$/.exec(col);
+    return mm ? cleanName(mm[1]) : cleanName(col);
+  }
+  return cleanName(col);
+}
+
+function getValue(row: any, key: string): any {
+  if (row == null || typeof row !== "object") return row;
+  if (key in row) return row[key];
+  if (key.toLowerCase() in row) return row[key.toLowerCase()];
+  if (key.toUpperCase() in row) return row[key.toUpperCase()];
+  return null;
+}
+
+function resultToMarkdownTable(result: any, query: string): string {
+  if (typeof result === "string") return result;
+  if (!Array.isArray(result) || result.length === 0) return "No results or invalid data format.";
+  const available = result[0] && typeof result[0] === "object" ? Object.keys(result[0]) : [];
+  let headers = extractHeadersFromQuery(query);
+  headers = headers.length === 0 ? available : headers.filter((h) => available.includes(h));
+  if (headers.length === 0) headers = Object.keys(result[0]);
+  if (headers.length === 0) return "No headers found in the result.";
+  const headerRow = `| ${headers.join(" | ")} |`;
+  const sep = `|${"---|".repeat(headers.length)}`;
+  const rows = result.map(
+    (row) => `| ${headers.map((h) => String(getValue(row, h) ?? "").trim()).join(" | ")} |`
+  );
+  return [headerRow, sep, ...rows].join("\n");
+}
+
+function formatItem(item: any): string {
+  if (typeof item === "string") return item.trim();
+  if (item && typeof item === "object") {
+    const vals = Object.values(item);
+    if (vals.length === 1) return formatItem(vals[0]);
+    return Object.entries(item)
+      .map(([k, v]) => `${k}: ${v}`)
+      .join(", ");
+  }
+  return String(item);
+}
+
+function resultToMarkdownList(result: any, query: string): string {
+  if (typeof result === "string") return `- ${result}`;
+  if (!Array.isArray(result) || result.length === 0) return "No results or invalid data format.";
+  const available = result[0] && typeof result[0] === "object" ? Object.keys(result[0]) : [];
+  let headers = extractHeadersFromQuery(query);
+  headers = headers.length === 0 ? available : headers.filter((h) => available.includes(h));
+  return result
+    .map((row) => {
+      const value =
+        headers.length === 0
+          ? formatItem(row)
+          : headers.map((h) => getValue(row, h)).map(formatItem).join(": ");
+      return `- ${value}`;
+    })
+    .join("\n");
+}
+
+function processDuckdbQueries(content: string, dbDir: string): string {
+  let out = content.replace(/```dsql-table\n([\s\S]*?)```/g, (_full, query) => {
+    const r = duckdbQueryTemp(query, dbDir);
+    return r.ok ? resultToMarkdownTable(r.data, query) : `Error executing query: ${r.data}`;
+  });
+  out = out.replace(/```dsql-list\n([\s\S]*?)```/g, (_full, query) => {
+    const r = duckdbQueryTemp(query, dbDir);
+    return r.ok ? resultToMarkdownList(r.data, query) : `Error executing query: ${r.data}`;
+  });
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Path mapping (port of replace_path_prefix + preserve_relative_prefix_and_slugify)
+// ---------------------------------------------------------------------------
+
+function replacePathPrefix(path: string, oldPrefix: string, newPrefix: string): string {
+  const normalizedPath = nodePath.resolve(path);
+  const normalizedOld = nodePath.resolve(oldPrefix);
+  const relativePart = P.relative(normalizedOld, normalizedPath);
+  const insidePrefix = relativePart !== normalizedPath && !relativePart.startsWith("..");
+  if (insidePrefix) {
+    const result = P.join(newPrefix, relativePart);
+    return path.startsWith("../") ? result : nodePath.resolve(result);
+  }
+  // fallback
+  const oldBase = P.basename(oldPrefix);
+  const newBase = P.basename(newPrefix);
+  return path.replace(new RegExp(`(^|/)${oldBase}(/|$)`), `$1${newBase}$2`);
+}
+
+function preserveRelativePrefixAndSlugify(path: string): string {
+  if (path.endsWith(".mdx")) return path;
+  const m = /^(\.\.\/)+/.exec(path);
+  if (m) {
+    const prefix = m[0];
+    const rest = path.slice(prefix.length);
+    return prefix + slugifyPath(rest);
+  }
+  return slugifyPath(path);
+}
+
+// ---------------------------------------------------------------------------
+// Driver
+// ---------------------------------------------------------------------------
+
+function computeFileHash(file: string): string {
+  return createHash("md5").update(fs.readFileSync(file)).digest("hex");
+}
+
+interface Opts {
+  vault: string;
+  output: string;
+  dbDir: string;
+}
+
+function processFileContent(file: string, vaultDir: string, allFiles: string[], dbDir: string): string {
+  const content = fs.readFileSync(file, "utf8");
+  const links = extractLinks(content);
+  const resolved = resolveLinks(links, allFiles, vaultDir);
+  let out = convertLinks(content, resolved, file);
+  out = processDuckdbQueries(out, dbDir);
+  out = slugifyMarkdownLinks(out);
+  out = wrapMultilineKatex(out);
+  return out;
+}
+
+export function runExport(opts: Opts): { exported: number; skipped: number } {
+  const { vault: vaultDir, output: exportpath, dbDir } = opts;
+  const ignorePatterns = readExportIgnoreFile(P.join(vaultDir, ".export-ignore"));
+  const paths = listFilesRecursive(vaultDir);
+  const allFiles = paths.filter((p) => {
+    try {
+      return fs.statSync(p).isFile();
+    } catch {
+      return false;
+    }
+  });
+  const allValidFiles = allFiles.filter((f) => !ignored(f, ignorePatterns, vaultDir));
+
+  let exported = 0;
+  let skipped = 0;
+
+  for (const file of allValidFiles) {
+    if (!containsRequiredFrontmatterKeys(file)) continue;
+    const exportFile = replacePathPrefix(file, vaultDir, exportpath);
+    const slugifiedExportFile = preserveRelativePrefixAndSlugify(exportFile);
+    const dirname = P.dirname(slugifiedExportFile);
+    const basename = P.basename(slugifiedExportFile);
+    if ((basename === "home.md" || basename === "index.md") && dirname === exportpath) {
+      skipped++;
+      continue;
+    }
+    const converted = processFileContent(file, vaultDir, allValidFiles, dbDir);
+    fs.mkdirSync(P.dirname(slugifiedExportFile), { recursive: true });
+    fs.writeFileSync(slugifiedExportFile, converted);
+    exported++;
+  }
+  return { exported, skipped };
+}
+
+function parseArgs(argv: string[]): Opts {
+  let vault = "../../vault";
+  let output = "../../public/content";
+  let dbDir = "../../db";
+  for (let i = 0; i < argv.length; i++) {
+    if ((argv[i] === "--vault" || argv[i] === "-v") && argv[i + 1]) vault = argv[++i];
+    else if ((argv[i] === "--output" || argv[i] === "-o") && argv[i + 1]) output = argv[++i];
+    else if (argv[i] === "--db" && argv[i + 1]) dbDir = argv[++i];
+  }
+  return { vault, output, dbDir };
+}
+
+if (require.main === module) {
+  const opts = parseArgs(process.argv.slice(2));
+  const start = Date.now();
+  const { exported, skipped } = runExport(opts);
+  console.error(
+    `export-markdown(ts): exported ${exported}, skipped(root) ${skipped} in ${(
+      (Date.now() - start) /
+      1000
+    ).toFixed(1)}s -> ${opts.output}`
+  );
+}

--- a/scripts/export-markdown.ts
+++ b/scripts/export-markdown.ts
@@ -19,10 +19,10 @@
  * lib/obsidian-compiler; when run from repo root pass --vault vault --output public/content)
  */
 import * as fs from "fs";
-import * as fsp from "fs/promises";
 import * as nodePath from "path";
 import { execFileSync } from "child_process";
 import { createHash } from "crypto";
+import * as yaml from "js-yaml";
 
 const P = nodePath.posix;
 
@@ -154,10 +154,6 @@ export function wrapMultilineKatex(content: string): string {
 // Frontmatter (port of Memo.Common.Frontmatter)
 // ---------------------------------------------------------------------------
 
-// gray-matter/js-yaml are borrowed from the parent node_modules.
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const yaml = require("js-yaml");
-
 function parseFrontmatter(content: string): any | null {
   // ~r/^---\n(.*?)\n---/s
   const m = /^---\n([\s\S]*?)\n---/.exec(content);
@@ -279,12 +275,15 @@ export function extractLinks(content: string): string[] {
   let m: RegExpExecArray | null;
   EXTRACT_RE.lastIndex = 0;
   while ((m = EXTRACT_RE.exec(content)) !== null) {
-    // Mirror the Elixir flat_map clause ordering (first non-nil group wins).
-    if (m[1] !== undefined) links.push(m[1]); // image embed
-    else if (m[3] !== undefined) links.push(m[2]); // [[x.md|alt]] -> pre (the path)
-    else if (m[5] !== undefined) links.push(m[4]); // [[x|alt]] -> file
-    else if (m[6] !== undefined) links.push(m[6]); // [[x.md]]
-    else if (m[7] !== undefined) links.push(m[7]); // [[x]]
+    // Faithful to the Elixir flat_map: its clauses match on the arity of the
+    // Regex.scan result list, and Elixir drops trailing non-participating groups. So
+    // plain [[x]] (group 7 -> 8-elem list) and [[x.md]] (group 6 -> 7-elem list) match
+    // NONE of the 2/4/6-arity clauses and are silently dropped. Only three shapes are
+    // ever extracted: image embeds, the .md path of [[x.md|alt]], the file of [[x|alt]].
+    if (m[1] !== undefined) links.push(m[1]); // ![[img]]  -> 2-elem clause
+    else if (m[3] !== undefined) links.push(m[2]); // [[x.md|alt]] -> 4-elem clause (pre)
+    else if (m[5] !== undefined) links.push(m[4]); // [[x|alt]]    -> 6-elem clause (file)
+    // [[x.md]] and [[x]] intentionally NOT extracted (Elixir arity-drop parity).
   }
   return links;
 }
@@ -588,7 +587,19 @@ function processFileContent(file: string, vaultDir: string, allFiles: string[], 
 export function runExport(opts: Opts): { exported: number; skipped: number } {
   const { vault: vaultDir, output: exportpath, dbDir } = opts;
   const ignorePatterns = readExportIgnoreFile(P.join(vaultDir, ".export-ignore"));
-  const paths = listFilesRecursive(vaultDir);
+  let paths = listFilesRecursive(vaultDir);
+  // Debug/parity hook: N2_ORDER_FILE pins the file-traversal order (one path per line) so
+  // the port can be proven byte-identical to the Elixir oracle under IDENTICAL ordering,
+  // isolating the fuzzy-resolver's order-sensitivity from any logic difference. Not used in
+  // production (production uses the deterministic sorted order Node yields).
+  if (process.env.N2_ORDER_FILE && fs.existsSync(process.env.N2_ORDER_FILE)) {
+    const order = fs
+      .readFileSync(process.env.N2_ORDER_FILE, "utf8")
+      .split("\n")
+      .filter((l) => l !== "");
+    const rank = new Map(order.map((p, i) => [p, i]));
+    paths = [...paths].sort((a, b) => (rank.get(a) ?? 1e9) - (rank.get(b) ?? 1e9));
+  }
   const allFiles = paths.filter((p) => {
     try {
       return fs.statSync(p).isFile();
@@ -631,7 +642,7 @@ function parseArgs(argv: string[]): Opts {
   return { vault, output, dbDir };
 }
 
-if (require.main === module) {
+if (import.meta.url === `file://${process.argv[1]}`) {
   const opts = parseArgs(process.argv.slice(2));
   const start = Date.now();
   const { exported, skipped } = runExport(opts);

--- a/test/export-markdown.test.ts
+++ b/test/export-markdown.test.ts
@@ -1,0 +1,65 @@
+/**
+ * @file export-markdown.test.ts
+ * @description Unit coverage for the TypeScript port of the Elixir `mix export_markdown`
+ * compiler (scripts/export-markdown.ts). Locks the transform behaviors that byte-parity
+ * with the Elixir oracle depends on. The full 655/655 byte-parity run against the real
+ * vault is documented in docs/cf-migration/compiler-rewrite.md; these are the fast unit
+ * guards for the individual transforms.
+ */
+
+import { describe, test, expect } from 'vitest';
+import {
+  slugify,
+  slugifyPath,
+  slugifyLinkPath,
+  wrapMultilineKatex,
+  extractLinks,
+} from '../scripts/export-markdown';
+
+describe('slugify', () => {
+  test('lowercases, strips punctuation, collapses spaces/dashes', () => {
+    expect(slugify('My Cool Note!')).toBe('my-cool-note');
+    expect(slugify('  a--b  ')).toBe('a-b');
+  });
+  test('is lossy on non-ASCII (matches the Elixir a-z0-9 strip)', () => {
+    // Elixir Slugify.slugify strips anything outside [a-z0-9\s_-] AFTER downcase, so
+    // Vietnamese diacritics are dropped rather than transliterated.
+    expect(slugify('Đặng Anh')).toBe('ng-anh');
+  });
+});
+
+describe('slugifyPath / slugifyLinkPath', () => {
+  test('slugifies directory + filename, preserves extension', () => {
+    expect(slugifyPath('Some Dir/My File.md')).toBe('some-dir/my-file.md');
+  });
+  test('leaves external URLs and anchors untouched, keeps fragment casing', () => {
+    expect(slugifyLinkPath('https://x.com/A')).toBe('https://x.com/A');
+    expect(slugifyLinkPath('Some Note.md#Heading')).toBe('some-note.md#Heading');
+  });
+});
+
+describe('wrapMultilineKatex', () => {
+  test('single-line block is untouched', () => {
+    expect(wrapMultilineKatex('$$a+b$$')).toBe('$$a+b$$');
+  });
+  test('multi-line block gets surrounding newlines', () => {
+    expect(wrapMultilineKatex('$$a\nb$$')).toBe('\n$$a\nb$$\n');
+  });
+});
+
+describe('extractLinks (Elixir arity-drop parity)', () => {
+  test('extracts image embeds, [[x.md|alt]] paths, and [[x|alt]] files', () => {
+    expect(extractLinks('![[img.png]]')).toEqual(['img.png']);
+    expect(extractLinks('[[deep/note.md|Alt]]')).toEqual(['deep/note.md']);
+    expect(extractLinks('[[Some Note|Alt]]')).toEqual(['Some Note']);
+  });
+  test('does NOT extract plain [[x]] or [[x.md]] (Elixir drops these)', () => {
+    // The Elixir flat_map clauses match on the Regex.scan result arity; plain wikilinks
+    // land on clauses that never fire, so they are silently dropped. Extracting them here
+    // would over-populate the fuzzy resolver and break byte-parity on short ambiguous
+    // keys (e.g. [[Go]] matching an unrelated asset filename by substring).
+    expect(extractLinks('[[Go]]')).toEqual([]);
+    expect(extractLinks('[[plain-note.md]]')).toEqual([]);
+    expect(extractLinks('see [[1]] and [[2]] refs')).toEqual([]);
+  });
+});


### PR DESCRIPTION
## CF-N.2: Elixir `export_markdown` -> TypeScript rewrite (the REAL sub-goal)

Rewrites the Elixir `mix export_markdown` content-compilation step
(`lib/obsidian-compiler/`) as `scripts/export-markdown.ts` so the memo.d.foundation build
can run on one stack (TS in GitHub Actions), byte-comparable to the Elixir output.

This is the upstream half that the merged `build-inventory.md` (CF-N.3) flagged as *not*
done: the downstream artifact layer (`memo-build.ts` + `generate-*.ts` + `next build`) was
already TS; the vault -> `public/content` markdown compilation was still Elixir. This PR
ports that half and proves parity by running BOTH compilers on the same real vault snapshot.

**The Elixir compiler is retained** as oracle + fallback. No `Makefile`/`Dockerfile`/CI
switch-over here, that is a later, gated step.

### What was ported

Full per-file content pipeline from `Memo.ExportMarkdown` + `Common.{Slugify, LinkUtils,
KatexUtils, Frontmatter, FileUtils, DuckDBUtils}`: wikilink extract/resolve/convert (4
ordered code-block-aware passes), slugify (path + link + markdown-link), `dsql-table` /
`dsql-list` DuckDB blocks (shells the `duckdb` CLI with the identical `IMPORT DATABASE` +
`markdown_link` TEMP MACRO args), multiline-KaTeX wrap, the frontmatter export gate, the
`.export-ignore` filter, and the path/slug export mapping (incl. `.mdx` passthrough and the
root `home.md`/`index.md` skip). Design note + full mapping table:
`docs/cf-migration/compiler-rewrite.md`.

### Parity run-table (Elixir oracle vs TS port, real `dwarvesf/brainery` vault, 687 source md)

| Step | Command | Result |
| --- | --- | --- |
| Elixir oracle export | `mix export_markdown --vault ../../vault --output ../../public/content` | PASS, 655 md/mdx |
| TS port export | `tsx scripts/export-markdown.ts --vault ../../vault --output ../../ts-content --db ../../db` | PASS, 655 md/mdx |
| File-set diff | only-Elixir / only-TS | **0 / 0** |
| Byte diff (every common file) | 655 common files | **655 / 655 byte-identical** |
| **Byte-parity** | | **100.00%** |
| Elixir determinism | second full export, self-diff | 0 files differ |
| Unit tests | `vitest run test/export-markdown.test.ts` | 8/8 pass |

### The one real parity bug found + fixed

Elixir's `extract_links` `flat_map` clauses match on the **arity** of each `Regex.scan`
result list, and Elixir drops trailing non-participating capture groups, so plain `[[x]]`
and `[[x.md]]` wikilinks are **silently dropped** (they land on no clause). The first cut of
the port extracted them (the "obvious" regex reading), which over-fed the fuzzy resolver:
short ambiguous keys like `[[Go]]`/`[[1]]` substring-matched unrelated asset filenames and
emitted a different (still-broken `[alt]()`) target than the Elixir oracle. Reproducing the
arity-drop behavior, not extracting plain `[[x]]`/`[[x.md]]`, closed the last 3 files to
100%. The vitest test locks this case.

### Honest gap list (deliberately not in the content port; none affect the 100% md parity)

- **Asset-folder + `db/` copy**: byte-identical file copies, no transform. Mechanical to add.
- **Incremental cache** (`.memo_export_cache.json`): a re-run skip optimization; a clean CI
  build processes every file, so it changes no output.
- **`mix duckdb.export`** (parquet + embeddings regen): out of scope, a separate DuckDB /
  embeddings pipeline needing paid providers, run only by manual `workflow_dispatch`. Its
  freshness gap was already documented in `build-inventory.md`.
- **Build switch-over**: not done on purpose. Elixir stays wired in as oracle/fallback.

### Notes

- Ran on a local checkout of the 568M `vault` submodule (https override for the SSH
  `.gitmodules` URL, same as CF-N.3). Node deps borrowed read-only from a sibling
  `node_modules`; no install in the worktree. The vault submodule pointer is unchanged.
- Parity output trees are not committed (kept out of the worktree). `N2_ORDER_FILE` debug
  hook can pin traversal order for future re-verification.
