### PR TITLE
fix(build): unbreak the Railway production build typecheck

### DIFF
--- a/scripts/upload-to-r2.ts
+++ b/scripts/upload-to-r2.ts
@@ -299,7 +299,9 @@ function createR2ClientFromEnv(env: NodeJS.ProcessEnv = process.env): R2Client {
     return fetch(`https://${host}${canonicalUri}`, {
       method,
       headers: { ...headers, authorization },
-      body,
+      // Buffer is a Uint8Array at runtime, but the DOM lib's BodyInit doesn't
+      // accept Node's Buffer type; re-wrap so `next build`'s typecheck passes.
+      body: body ? new Uint8Array(body) : undefined,
     });
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,5 +24,5 @@
     ".next/types/**/*.ts",
     "src/pages/test.mdx"
   ],
-  "exclude": ["node_modules", "vault"]
+  "exclude": ["node_modules", "vault", "functions"]
 }


### PR DESCRIPTION
## Problem

Railway production builds for memo.d.foundation have been failing since the cf-migration PRs (#303/#304) merged on 07-22/23. Build-failure email received; the live site keeps serving the last good deploy but new content stopped flowing.

## Root cause

`make build-static` runs `next build`, whose typecheck sweeps every `*.ts` in the repo. Two of our new files fail it:

1. **`functions/_middleware.ts`** (#304) statically imports `./_generated-redirect-map.js`, a build-time GENERATED file that is intentionally not committed. `functions/` is a CF Pages artifact dir compiled by Pages' own toolchain and should never be part of the Next app typecheck → added to tsconfig `exclude`.
2. **`scripts/upload-to-r2.ts`** (#303) passes a Node `Buffer` as a `fetch` body. Runtime-fine (Buffer IS a Uint8Array), but the DOM lib's `BodyInit` type rejects it → re-wrapped as `new Uint8Array(body)`.

Neither was caught pre-merge because **the repo's CI has no build job**, only vitest + the parquet/submodule monitors; `next build` runs nowhere but Railway.

## Proof

Full Railway build sequence run locally on this branch, all exit 0:

```
pnpm install --no-frozen-lockfile   → 0
pnpm run build                      → 0   (was: 2 type errors on main)
pnpm run generate-nginx-conf        → 0
pnpm run build-ci-lint              → 0
```

## Follow-up (not in this PR)

Add a `next build` job (or at least `tsc --noEmit`) to CI so build breaks are caught pre-merge instead of post-merge on Railway.
