### PR TITLE
fix(cf-pages): serve 5 oversize assets via R2 proxy

### DIFF
--- a/docs/cf-migration/M4-02-PAGES-CUTOVER-RECORD.md
+++ b/docs/cf-migration/M4-02-PAGES-CUTOVER-RECORD.md
@@ -92,11 +92,41 @@ key prefixes, sizes verified by re-download):
    HEAD-before-PUT resumes cleanly). Nothing currently consumes the `out/`
    mirror.
 2. **5 asset files exceed Pages' 25 MiB per-file limit** and were excluded
-   from the deploy (Pages hard-rejects them). They 404 on pages.dev but serve
-   on Railway: `research/assets/builder-design-pattern.pdf` (33 MB, + 2 alias
-   copies) and `playground/topics/blockchain/assets/build_custom_ai_agent_with_elizaos_result.gif`
-   (28 MB, + 1 alias copy). Follow-up options: compress them in the vault, or
-   serve them from R2 via the middleware.
+   from the deploy (Pages hard-rejects them): the same PDF is physically
+   duplicated at 3 paths under `public/content/` (34,491,168 bytes each) and
+   the same GIF at 2 paths (29,778,758 bytes each), the vault export copies
+   an asset into every category tree (`research/`, `playground/`) that
+   references it, so one underlying file becomes several identical build
+   outputs.
+
+   **Fixed** (`fix/oversize-assets-r2`, PR #TODO, 2026-07-23): each distinct
+   file (2 total) uploaded once to `memo-derived` R2 at
+   `assets/oversize/<filename>` via `wrangler r2 object put`, verified
+   byte-identical by re-download + SHA-256. `functions/_middleware.ts` gained
+   a small hand-maintained map (`functions/lib/oversize-assets.ts`, 5 paths →
+   2 R2 keys) checked before the redirect/feed logic: a hit fetches the
+   object via a private R2 binding (`wrangler.toml` `[[r2_buckets]]`,
+   `MEMO_DERIVED`) and streams it back with `Content-Type`/`ETag` from R2
+   metadata plus a 1-year immutable `Cache-Control`. The bucket stays
+   private; nothing is exposed via R2's public r2.dev domain. Redeployed via
+   `wrangler pages deploy out/ --branch main` (no site rebuild needed, only
+   the Functions bundle + `wrangler.toml` binding changed).
+
+   All 5 paths verified 200 on the live `memo.d.foundation` domain with
+   correct `Content-Length` (34,491,168 / 29,778,758) and, for one sampled
+   path, a byte-identical SHA-256 against the source file. Root, `/rss.xml`,
+   a garbage-path 404, and an existing small PDF at the same directory shape
+   (`singleton-design-pattern.pdf`) re-verified 200/404 as expected, no
+   regression.
+
+   | Path                                                                                         | Status | Content-Length |
+   | -------------------------------------------------------------------------------------------- | ------ | -------------- |
+   | `/content/research/assets/builder-design-pattern.pdf`                                        | 200    | 34,491,168     |
+   | `/content/research/topics/architecture/assets/builder-design-pattern.pdf`                    | 200    | 34,491,168     |
+   | `/content/playground/topics/architecture/assets/builder-design-pattern.pdf`                  | 200    | 34,491,168     |
+   | `/content/research/topics/blockchain/assets/build_custom_ai_agent_with_elizaos_result.gif`   | 200    | 29,778,758     |
+   | `/content/playground/topics/blockchain/assets/build_custom_ai_agent_with_elizaos_result.gif` | 200    | 29,778,758     |
+
 3. **BSD vs GNU `cp`:** the Makefile's `cp -r db/ out/` puts files at
    `out/db/` on Linux but at `out/` on macOS; fixed by hand this run. Only
    matters for local macOS builds; the Pages CI build command should run on

--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -23,6 +23,7 @@
 // tighten these types before the first real deploy.
 import { REDIRECT_MAP } from './_generated-redirect-map.js';
 import { feedLimitFilename } from './lib/feed-limit.js';
+import { OVERSIZE_ASSET_MAP } from './lib/oversize-assets.js';
 
 async function serveWithFallback(
   assets: { fetch: (req: Request) => Promise<Response> },
@@ -42,6 +43,21 @@ export const onRequest = async (context: any): Promise<Response> => {
   const { request, env, next } = context;
   const url = new URL(request.url);
   const { pathname } = url;
+
+  // 5 vault assets exceed Pages' 25 MiB per-file upload limit and are
+  // excluded from `out/` at build time (see M4-02-PAGES-CUTOVER-RECORD.md).
+  // They were uploaded once to the memo-derived R2 bucket; proxy them
+  // through here instead of a redirect, so the bucket can stay private.
+  const oversizeKey = OVERSIZE_ASSET_MAP[pathname];
+  if (oversizeKey) {
+    const object = await env.MEMO_DERIVED.get(oversizeKey);
+    if (object === null) return next();
+    const headers = new Headers();
+    object.writeHttpMetadata(headers);
+    headers.set('etag', object.httpEtag);
+    headers.set('cache-control', 'public, max-age=31536000, immutable');
+    return new Response(object.body, { headers });
+  }
 
   const redirectTarget = REDIRECT_MAP[pathname];
   if (redirectTarget && redirectTarget !== pathname) {
@@ -66,7 +82,13 @@ export const onRequest = async (context: any): Promise<Response> => {
       feedMatch[1],
       url.searchParams.get('limit'),
     );
-    return serveWithFallback(env.ASSETS, url.origin, limitedPath, pathname, request);
+    return serveWithFallback(
+      env.ASSETS,
+      url.origin,
+      limitedPath,
+      pathname,
+      request,
+    );
   }
   if (pathname === '/feed/index.xml') {
     const limitedPath = feedLimitFilename(

--- a/functions/lib/oversize-assets.ts
+++ b/functions/lib/oversize-assets.ts
@@ -1,0 +1,24 @@
+// Hand-maintained map (unlike _generated-redirect-map.ts) for the small,
+// fixed set of assets that exceed Pages' 25 MiB per-file limit and were
+// excluded from the `out/` deploy. Each entry's value is the R2 object key
+// under the memo-derived bucket (uploaded once via `wrangler r2 object
+// put`); functions/_middleware.ts proxies the request through the R2
+// binding rather than redirecting, so the bucket doesn't need to be public.
+//
+// Source file identical across every alias path listed for it (same
+// physical file duplicated in public/content/ by the vault export); one R2
+// object per distinct file is enough. See
+// docs/cf-migration/M4-02-PAGES-CUTOVER-RECORD.md "Deviations and known
+// gaps" #2.
+export const OVERSIZE_ASSET_MAP: Record<string, string> = {
+  '/content/research/assets/builder-design-pattern.pdf':
+    'assets/oversize/builder-design-pattern.pdf',
+  '/content/research/topics/architecture/assets/builder-design-pattern.pdf':
+    'assets/oversize/builder-design-pattern.pdf',
+  '/content/playground/topics/architecture/assets/builder-design-pattern.pdf':
+    'assets/oversize/builder-design-pattern.pdf',
+  '/content/research/topics/blockchain/assets/build_custom_ai_agent_with_elizaos_result.gif':
+    'assets/oversize/build_custom_ai_agent_with_elizaos_result.gif',
+  '/content/playground/topics/blockchain/assets/build_custom_ai_agent_with_elizaos_result.gif':
+    'assets/oversize/build_custom_ai_agent_with_elizaos_result.gif',
+};

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,6 +3,15 @@ pages_build_output_dir = "out"
 compatibility_date = "2026-07-23"
 compatibility_flags = ["nodejs_compat"]
 
+# Serves the handful of vault assets that exceed Pages' 25 MiB per-file
+# upload limit (excluded from the `out/` deploy, see functions/_middleware.ts
+# and docs/cf-migration/M4-02-PAGES-CUTOVER-RECORD.md "Deviations and known
+# gaps" #2). Bucket stays private; the Function proxies the object through,
+# it is not exposed via R2's public r2.dev domain.
+[[r2_buckets]]
+binding = "MEMO_DERIVED"
+bucket_name = "memo-derived"
+
 # Pages Functions live in ./functions (repo root, sibling to `out/`) and are
 # auto-detected by Cloudflare Pages; no explicit config needed for them here.
 #


### PR DESCRIPTION
## Summary

- 5 URLs on `memo.d.foundation` were 404ing because the underlying files exceed Cloudflare Pages' 25 MiB per-file upload limit: a 33 MB PDF (physically duplicated at 3 paths under `public/content/`) and a 28 MB GIF (2 paths).
- Each distinct file is uploaded once to the existing `memo-derived` R2 bucket (`assets/oversize/<filename>`, verified byte-identical by re-download + SHA-256).
- `functions/_middleware.ts` gained a small hand-maintained map (`functions/lib/oversize-assets.ts`, 5 paths -> 2 R2 keys) checked ahead of the redirect/feed logic: a hit proxies the object through a private R2 binding (`wrangler.toml` `[[r2_buckets]]` `MEMO_DERIVED`), streamed back with the R2-derived `Content-Type`/`ETag` and a 1-year immutable `Cache-Control`. The bucket stays private (no public r2.dev domain needed).
- Deployed to Production (`wrangler pages deploy out/ --branch main`, Functions bundle + binding only, no site rebuild) and verified live against `memo.d.foundation` before opening this PR.

## Test plan

- [x] Both files verified byte-identical in R2 vs source (SHA-256 match) after upload.
- [x] All 5 target paths return `200` on live `memo.d.foundation` with correct `Content-Length` (34,491,168 for the PDF, 29,778,758 for the GIF).
- [x] One path spot-checked byte-for-byte (SHA-256 match) against the source file.
- [x] No regression: `/` (200), `/rss.xml` (200), a garbage path (404), and an existing small PDF at the same directory shape (`singleton-design-pattern.pdf`, 200) all re-verified.
- [x] `tsc --noEmit` clean on the changed Functions code.
