### PR TITLE
chore(ci): add weekly schedule to the vault reindex workflow

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -2,6 +2,14 @@ name: Update submodules
 
 on:
   workflow_dispatch:
+  schedule:
+    # Weekly, Sunday 20:00 UTC: ahead of publish-pages.yml's daily 22:00 UTC
+    # cron so a fresh reindex is available before that publish. Runs
+    # generate-summary + duckdb-export against every vault file via paid
+    # OpenAI/Gemini/Jina APIs, so this stays weekly, not daily, to bound
+    # embedding-regen cost. Tune the cadence if staleness or cost pressure
+    # changes.
+    - cron: '0 20 * * 0'
 
 concurrency:
   group: ${{ github.repository }}-workflow


### PR DESCRIPTION
## Problem

`.github/workflows/dispatch.yml` ("Update submodules") is the only workflow that regenerates `db/vault.parquet` (content DB, including embeddings via OpenAI/Gemini/Jina). It has always been `workflow_dispatch`-only, no schedule, so it only runs when someone remembers to trigger it by hand. That's exactly how it went ~9 months stale before anyone noticed (traced in `docs/cf-migration/build-inventory.md` and flagged as a known, undecided gap in `docs/cf-migration/content-sot.md`).

## Change

Adds a `schedule:` trigger alongside `workflow_dispatch:`:

```yaml
schedule:
  - cron: '0 20 * * 0'   # Sunday 20:00 UTC
```

`workflow_dispatch:` stays, so manual re-runs still work.

## Why weekly, and why Sunday 20:00 UTC

This job calls paid embedding APIs (`OPENAI_API_KEY`, `GEMINI_API_KEY`, `JINA_API_KEY`) against every vault file on each run, so the cadence is a cost/staleness tradeoff, not a free choice. Weekly keeps the worst-case staleness bounded to ~7 days instead of indefinite, without triggering full-vault embedding regen daily.

Sunday 20:00 UTC lands 2 hours ahead of `publish-pages.yml`'s existing daily `0 22 * * *` cron, so a fresh reindex is available before that day's publish, on a day/time that's otherwise low-traffic for the pipeline.

**This is a starting point, not a fixed answer** — the interval and time are tunable. If actual embedding-API spend or staleness tolerance turns out different than assumed here, adjust the cron expression; nothing else depends on this exact value.

## Verification

- `dispatch.yml` YAML parses cleanly (`yaml.safe_load`).
- `schedule` + `workflow_dispatch` both present under `on:`; no other workflow behavior changed.

Not merging — leaving this for review/tuning.