### PR TITLE
chore(ci): stop committing regenerated vault.parquet to git

### DIFF
--- a/.github/workflows/add-mint-post.yml
+++ b/.github/workflows/add-mint-post.yml
@@ -26,6 +26,18 @@ jobs:
           submodules: recursive
           fetch-depth: 1
 
+      # db/vault.parquet is no longer committed to git (dispatch.yml
+      # regenerates and uploads it to R2 instead). The "Get changed files"
+      # step below queries this file directly, so pull the latest copy down
+      # first.
+      - name: Download latest vault.parquet from R2
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          npx wrangler@4 r2 object get "memo-derived/derived/latest/db/vault.parquet" \
+            --file db/vault.parquet --remote
+
       - name: Install Vault CLI
         run: |
           rm -rf vault_1.15.5_linux_amd64.zip

--- a/.github/workflows/deploy-arweave.yml
+++ b/.github/workflows/deploy-arweave.yml
@@ -23,6 +23,18 @@ jobs:
           submodules: recursive
           fetch-depth: 1
 
+      # db/vault.parquet is no longer committed to git (dispatch.yml
+      # regenerates and uploads it to R2 instead). The "Get changed files"
+      # step below queries this file directly, so pull the latest copy down
+      # first.
+      - name: Download latest vault.parquet from R2
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          npx wrangler@4 r2 object get "memo-derived/derived/latest/db/vault.parquet" \
+            --file db/vault.parquet --remote
+
       - name: Get changed files
         id: changed-files
         run: |

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -47,6 +47,21 @@ jobs:
           JINA_BASE_URL: ${{ secrets.JINA_BASE_URL }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 
+      # db/vault.parquet is regenerated every run (~22-27MB) and is no longer
+      # committed to git (157 stale commits, 2.3GB .git bloat). Publish it to
+      # R2 instead, at both an immutable per-SHA key and the mutable "latest"
+      # pointer consumers read; same bucket/key convention publish-pages.yml
+      # already uses for its derived-object uploads.
+      - name: Upload vault.parquet to R2
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          for prefix in "derived/${GITHUB_SHA}" "derived/latest"; do
+            npx wrangler@4 r2 object put "memo-derived/${prefix}/db/vault.parquet" \
+              --file db/vault.parquet --content-type application/octet-stream --remote
+          done
+
       - name: Commit and push changes
         uses: ./.github/actions/git-commit-push
         with:

--- a/.github/workflows/monitor-vault-parquet.yml
+++ b/.github/workflows/monitor-vault-parquet.yml
@@ -42,6 +42,17 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # db/vault.parquet is no longer committed to git (dispatch.yml
+      # regenerates and uploads it to R2 instead); pull the latest copy
+      # down before checking/monitoring it.
+      - name: Download latest vault.parquet from R2
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          npx wrangler@4 r2 object get "memo-derived/derived/latest/db/vault.parquet" \
+            --file db/vault.parquet --remote
+
       - name: Check vault.parquet exists
         run: |
           if [ ! -f "db/vault.parquet" ]; then
@@ -107,6 +118,17 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      # db/vault.parquet is no longer committed to git (dispatch.yml
+      # regenerates and uploads it to R2 instead); pull the latest copy
+      # down before validating it.
+      - name: Download latest vault.parquet from R2
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          npx wrangler@4 r2 object get "memo-derived/derived/latest/db/vault.parquet" \
+            --file db/vault.parquet --remote
 
       - name: Validate vault.parquet structure
         run: |

--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -122,6 +122,19 @@ jobs:
         working-directory: lib/obsidian-compiler
         run: mix export_markdown
 
+      # db/vault.parquet is no longer committed to git (dispatch.yml
+      # regenerates and uploads it to R2 instead). Pull the latest copy down
+      # before the build reads it (src/lib/db/utils.ts defaults to this
+      # path); db/schema.sql, db/load.sql, db/processing_metadata*.parquet
+      # stay git-tracked and are already present from the checkout.
+      - name: Download latest vault.parquet from R2
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          npx wrangler@4 r2 object get "memo-derived/derived/latest/db/vault.parquet" \
+            --file db/vault.parquet --remote
+
       # Same sequence as the cutover record and `make build-static`:
       # pnpm run build -> generate-nginx-conf -> build-ci-lint -> db copy.
       # PLAUSIBLE_API_TOKEN is optional; generate-pageviews degrades gracefully.

--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,8 @@ tsconfig.tsbuildinfo
 
 # wrangler local state (created by wrangler pages/r2/d1 commands)
 .wrangler/
+
+# regenerated on every dispatch.yml run and uploaded to R2 (memo-derived
+# bucket, derived/latest/db/vault.parquet); no longer committed, see
+# db/schema.sql and db/load.sql for the durable schema
+db/vault.parquet


### PR DESCRIPTION
## Summary

- `db/vault.parquet` was regenerated and force-committed on every `dispatch.yml` run (157 commits, ~22-27MB each), the main driver of `.git` growing to 2.3GB. It is now `.gitignore`d and `git rm --cached`, and routed through R2 (`memo-derived` bucket) instead, at the same `derived/<sha>/` + `derived/latest/` key convention `publish-pages.yml` already uses for its other derived-object uploads (`derived/latest/db/vault.parquet`).
- `dispatch.yml`: after `duckdb-export` regenerates the parquet, a new step uploads it to R2 (`memo-derived/derived/${GITHUB_SHA}/db/vault.parquet` and `memo-derived/derived/latest/db/vault.parquet`) instead of letting `git-commit-push` pick it up.
- `publish-pages.yml`, `add-mint-post.yml`, `deploy-arweave.yml`, `monitor-vault-parquet.yml` (both jobs): each reads `db/vault.parquet` directly from the checkout, so each gets a new step that downloads `derived/latest/db/vault.parquet` from R2 before that read happens.
- `db/schema.sql`, `db/load.sql`, `db/processing_metadata*.parquet` stay git-tracked; only the large regenerated blob moves out.

## Open questions / risks

**(a) This does not shrink the existing 2.3GB `.git` history.** The 157 stale commits with their ~22-27MB blobs each are still in history. Shrinking that needs a separate `git filter-repo` purge + force-push + everyone re-clones, which is out of scope for this PR (a build-path change should not also be a history rewrite in the same shot).

**(b) Recommend a manual `workflow_dispatch` to the `dev` environment as a smoke test before merging to main**, since this changes where the build reads its derived data from (git checkout -> R2 download). `publish-pages.yml` / `deploy.yml` already support `workflow_dispatch` with an `environment=dev` option for exactly this kind of test.

**(c) Trigger breakage, needs a decision):** `generate-redirects.yml`, `add-mint-post.yml`, and `deploy-arweave.yml` (a third one I found while auditing, not originally named) all trigger on:
```yaml
on:
  push:
    branches: [main]
    paths:
      - 'db/vault.parquet'
```
Once `dispatch.yml` stops committing `db/vault.parquet` to git, this path filter never matches again, these three workflows will **only run via manual `workflow_dispatch` from now on**, never automatically after a `duckdb-export`. I did NOT redesign the trigger in this PR (re-wiring it, e.g. to a `workflow_run` chained off `dispatch.yml`, or a `repository_dispatch` fired from the new R2-upload step, is a separate design decision with its own blast radius). I added the R2-download step to `add-mint-post.yml` and `deploy-arweave.yml` so a manual dispatch still works correctly (both query `db/vault.parquet` directly via DuckDB CLI in the workflow step); `generate-redirects.yml` doesn't actually read the parquet file itself (only used it as a trigger filter), so no data-read fix was needed there, just the same trigger caveat.

**Bonus fix (not explicitly requested, found during the audit):** `monitor-vault-parquet.yml` (both `monitor-vault` and `health-check` jobs) checks/validates `db/vault.parquet` directly from a bare checkout with no build step. Without the R2 download I added, this would have gone permanently red on its daily 9am UTC schedule the moment the parquet stopped being tracked. Fixed the same way as the others.

**Not touched:** `derived-to-r2.yml` also reads `db/vault.parquet` from a bare checkout, but it's `workflow_dispatch`-only and explicitly marked `DEPLOY-GATED` / dormant in its own header comment (needs R2 S3-compatible keys the account doesn't currently have, per `publish-pages.yml`'s own comment about why it uses `wrangler r2 object put` instead). Left it alone rather than wiring a download step into a workflow that isn't live.

## Key-naming convention

Confirmed, not guessed: the `derived/<sha>/db/vault.parquet` + `derived/latest/db/vault.parquet` key shape is documented verbatim in `scripts/upload-to-r2.ts`'s header comment and matches the literal `wrangler r2 object put` call already in `publish-pages.yml`'s "Upload derived objects to R2" step. All new upload/download steps reuse that exact convention.

## Verification

- `actionlint` on every touched workflow: no new errors or warnings (5 pre-existing shellcheck infos/warnings on `main`, same 5 count after this PR, all in code this PR didn't touch).
- No TypeScript files changed (YAML + `.gitignore` only), so `pnpm typecheck` doesn't apply.
