### PR TITLE
feat(ci): fail loud on an oversize asset missing from the R2 proxy map

### DIFF
--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -142,6 +142,9 @@ jobs:
 
       # Pages hard-rejects the WHOLE upload if any single file exceeds 25 MiB.
       # Same sweep the cutover did, generic by size, not a filename list.
+      # Before stripping, verify every oversize file already has an R2 proxy
+      # entry (scripts/verify-oversize-assets.ts); an unmapped file fails the
+      # step loudly instead of silently deploying without it (404 for readers).
       - name: Exclude files over the Pages 25 MiB per-file limit
         run: |
           over=$(find out -type f -size +25M)
@@ -149,6 +152,9 @@ jobs:
             echo "Excluding from deploy (Pages rejects files > 25 MiB):"
             while IFS= read -r f; do
               ls -lh "$f"
+            done <<< "$over"
+            echo "$over" | pnpm exec tsx scripts/verify-oversize-assets.ts out
+            while IFS= read -r f; do
               rm -f -- "$f"
             done <<< "$over"
           else

--- a/scripts/verify-oversize-assets.ts
+++ b/scripts/verify-oversize-assets.ts
@@ -1,0 +1,76 @@
+// Fails loud when the build is about to silently drop an oversize asset that
+// has no R2 proxy entry. Companion tripwire to verify-submodules.sh: the
+// publish-pages.yml "Exclude files over the Pages 25 MiB per-file limit" step
+// strips any file >25 MiB from `out/` before deploy (Pages hard-rejects the
+// whole upload otherwise) with no failure and no map update, so a reader
+// could hit a 404 for content that used to work. See PR #312,
+// docs/cf-migration/M4-02-PAGES-CUTOVER-RECORD.md "Deviations and known gaps" #2.
+//
+// Usage: pnpm exec tsx scripts/verify-oversize-assets.ts [out-dir]
+// Reads the paths about to be stripped (relative to repo root, e.g.
+// "out/content/research/assets/foo.pdf", one per line, matching `find
+// out -type f -size +25M` output) from stdin.
+import path from 'path';
+import { OVERSIZE_ASSET_MAP } from '../functions/lib/oversize-assets.js';
+
+// OVERSIZE_ASSET_MAP keys on the request pathname (e.g.
+// "/content/research/assets/foo.pdf"), so a stripped `out/`-relative file
+// path maps to a map key by dropping the out-dir prefix and adding a
+// leading slash.
+function toUrlPath(filePath: string, outDir: string): string {
+  const rel = path.relative(outDir, path.resolve(filePath));
+  return '/' + rel.split(path.sep).join('/');
+}
+
+export function findUnmapped(
+  strippedPaths: string[],
+  outDir: string,
+  map: Record<string, string> = OVERSIZE_ASSET_MAP,
+): string[] {
+  return strippedPaths.filter(f => !(toUrlPath(f, outDir) in map));
+}
+
+function readStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    process.stdin.setEncoding('utf-8');
+    process.stdin.on('data', chunk => (data += chunk));
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', reject);
+  });
+}
+
+async function main(): Promise<void> {
+  const outDir = path.resolve(process.argv[2] || 'out');
+  const strippedPaths = (await readStdin())
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean);
+
+  if (strippedPaths.length === 0) {
+    console.log('No files over 25 MiB were stripped; nothing to verify.');
+    return;
+  }
+
+  const unmapped = findUnmapped(strippedPaths, outDir);
+
+  if (unmapped.length > 0) {
+    console.error(
+      `ERROR: ${unmapped.length} oversize file(s) stripped from the deploy have no R2 proxy entry in functions/lib/oversize-assets.ts:`,
+    );
+    for (const f of unmapped) console.error(`  ${f}`);
+    console.error(
+      'Upload the file to R2 and add its path(s) to OVERSIZE_ASSET_MAP before this can deploy, or the content 404s for readers.',
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `All ${strippedPaths.length} stripped oversize file(s) are covered by the R2 proxy map.`,
+  );
+}
+
+main().catch(error => {
+  console.error('Error verifying oversize assets:', error);
+  process.exit(1);
+});

--- a/test/verify-oversize-assets.test.ts
+++ b/test/verify-oversize-assets.test.ts
@@ -1,0 +1,31 @@
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+import { findUnmapped } from '../scripts/verify-oversize-assets';
+
+// scripts/verify-oversize-assets.ts is the fail-loud tripwire the
+// publish-pages.yml strip step runs before deploy: it turns a silently
+// dropped oversize asset (no R2 proxy entry) into a non-zero exit instead of
+// a 404 readers only discover in production. Exercises findUnmapped (the
+// pure map-lookup, no filesystem/process dependency) against a synthetic map
+// so it doesn't depend on the real OVERSIZE_ASSET_MAP staying in sync.
+describe('findUnmapped (oversize asset R2 proxy map coverage)', () => {
+  const outDir = path.resolve('out');
+  const map = {
+    '/content/research/assets/mapped.pdf': 'assets/oversize/mapped.pdf',
+  };
+
+  it('passes a stripped file that already has a map entry (positive control)', () => {
+    const stripped = [path.join('out', 'content/research/assets/mapped.pdf')];
+    expect(findUnmapped(stripped, outDir, map)).toEqual([]);
+  });
+
+  it('fails a stripped file with no map entry (negative control)', () => {
+    const stripped = [
+      path.join('out', 'content/research/assets/mapped.pdf'),
+      path.join('out', 'content/research/assets/unmapped.pdf'),
+    ];
+    expect(findUnmapped(stripped, outDir, map)).toEqual([
+      path.join('out', 'content/research/assets/unmapped.pdf'),
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- Cloudflare Pages hard-rejects the whole deploy if any single uploaded file exceeds 25 MiB. `publish-pages.yml`'s "Exclude files over the Pages 25 MiB per-file limit" step already strips those files from `out/` before deploy, but silently: no failure, no check against `functions/lib/oversize-assets.ts` (the hand-maintained map that proxies known oversize assets through R2, added in #312). A newly landed oversize asset with no map entry currently deploys clean and just 404s for readers.
- Adds `scripts/verify-oversize-assets.ts`, run right before the strip step deletes the files: for every stripped path, it checks whether the equivalent request pathname is already a key in `OVERSIZE_ASSET_MAP`. Any unmapped file fails the workflow step loudly (non-zero exit, names every unmapped path). Fully-covered strips proceed as before with an informational log line.
- Scoped deliberately narrow per the ask: this does not automate the R2 upload + map entry itself (needs human review of routing behavior), only turns the silent gap into a loud CI failure, matching the existing `scripts/verify-submodules.sh` fail-loud pattern from #307.

## Test plan

- [x] `npx tsc --noEmit`, no errors from the new files (one pre-existing, unrelated error in `src/lib/content/markdown.ts` from a missing generated build artifact; repo has no `pnpm typecheck` script, confirmed via `grep typecheck package.json` and CI workflows).
- [x] `npx vitest run`, full suite passes, 83/83 (including 2 new tests: positive control, a mapped stripped file passes; negative control, an unmapped one is flagged).
- [x] Manual CLI check: piped a mapped path and an unmapped path through the script directly, exit 0 with a PASS line for the mapped case, exit 1 naming the file for the unmapped case.

https://claude.ai/code/session_013TRBs7f8CFixZJviYX8Z7P
