### PR TITLE
chore(build): call the TypeScript markdown compiler from the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ fetch-force:
 
 build:
 	@pnpm install --no-frozen-lockfile
-	@cd lib/obsidian-compiler && mix export_markdown
+	@pnpm exec tsx scripts/export-markdown.ts --vault vault --output public/content --db db
 	@$(MAKE) duckdb-export
 	@pnpm run build
 	@pnpm run generate-nginx-conf
@@ -28,14 +28,14 @@ build:
 
 build-static:
 	@pnpm install --no-frozen-lockfile
-	@cd lib/obsidian-compiler && mix export_markdown
+	@pnpm exec tsx scripts/export-markdown.ts --vault vault --output public/content --db db
 	@pnpm run build
 	@pnpm run generate-nginx-conf
 	@pnpm run build-ci-lint
 	@cp -r db/ out/
 
 run:
-	@cd lib/obsidian-compiler && mix export_markdown
+	@pnpm exec tsx scripts/export-markdown.ts --vault vault --output public/content --db db
 	@$(MAKE) duckdb-export
 	@pnpm run generate-menu
 	@pnpm run generate-menu-path-sorted


### PR DESCRIPTION
CI (`publish-pages.yml`, this PR's base) already invokes `scripts/export-markdown.ts`. The Makefile still called `mix export_markdown`, so a local `make build` ran a *different compiler* than production. This aligns them.

Three targets change (`build`, `build-static`, `run`), all to the exact invocation CI uses:

```
pnpm exec tsx scripts/export-markdown.ts --vault vault --output public/content --db db
```

Verified with `make -n build-static`, which now emits the TS call.

## What is still Elixir after this

`mix duckdb.export` (the reindexer, ported in #325 but not yet merged), plus `mix fetch`, `duckdb.export_pattern`, and `sync_hashnode`. Once #325 lands, one more Makefile pass plus deleting `lib/obsidian-compiler/` removes Elixir from the repo entirely.

Based on #318 rather than main because it needs that PR's two fixes to `export-markdown.ts` (the missing asset/db directory copy, and a path-prefix bug that only manifests when the script runs from the repo root, which is exactly how the Makefile calls it).
