### PR TITLE
fix(build): keep keywords on the frontmatter-only upsert

### DIFF
--- a/scripts/duckdb-export.ts
+++ b/scripts/duckdb-export.ts
@@ -19,6 +19,8 @@
  *     off upstream; the columns and the carry-forward behaviour are preserved.
  *   - The legacy processing_metadata migration paths are not ported (db/schema.sql has
  *     been on the per-file schema for a long time and cannot regress to the `id` shape).
+ *   - `keywords` is carried forward on the frontmatter-only upsert path, where the Elixir
+ *     wipes it. Marked `DIVERGENCE:` at batch_upsert_into_duckdb.
  *
  * Usage:
  *   tsx scripts/duckdb-export.ts [--vault vault] [--db db] [--format parquet]
@@ -684,7 +686,7 @@ function skipEmbeddings(): boolean {
 // DuckDB access
 // ---------------------------------------------------------------------------
 
-class Duck {
+export class Duck {
   private constructor(private readonly conn: DuckDBConnection) {}
 
   static async open(): Promise<Duck> {
@@ -711,6 +713,11 @@ class Duck {
   }
 }
 
+export function vaultTableDdl(): string {
+  const cols = ALLOWED_FRONTMATTER.map(([n, t]) => `${quoteIdent(n)} ${t}`).join(", ");
+  return `CREATE TABLE IF NOT EXISTS vault (${cols})`;
+}
+
 /**
  * Port of setup_database. The Elixir issues `IMPORT DATABASE '../../db'`, which replays
  * schema.sql then load.sql verbatim, and load.sql carries hardcoded '../../db/...' COPY
@@ -731,9 +738,7 @@ async function setupDatabase(db: Duck, dbDir: string): Promise<void> {
     }
   } else {
     console.error("duckdb-export: no exported database at " + dbDir + ", creating tables");
-    await db.exec(
-      `CREATE TABLE IF NOT EXISTS vault (${ALLOWED_FRONTMATTER.map(([n, t]) => `${quoteIdent(n)} ${t}`).join(", ")})`
-    );
+    await db.exec(vaultTableDdl());
     await db.exec(`CREATE TABLE IF NOT EXISTS processing_metadata (
       file_path TEXT PRIMARY KEY,
       last_processed_at TIMESTAMP,
@@ -1040,18 +1045,25 @@ async function runOrThrow(db: Duck, sql: string, what: string): Promise<void> {
   if (err) throw new Error(`${what}: ${err}`);
 }
 
-async function batchUpsertIntoDuckdb(db: Duck, processed: ProcessedFile[]): Promise<void> {
+export async function batchUpsertIntoDuckdb(db: Duck, processed: ProcessedFile[]): Promise<void> {
   const keys = ALLOWED_KEYS;
   const updateAll = keys.filter((k) => k !== "file_path").map((k) => `${quoteIdent(k)} = EXCLUDED.${quoteIdent(k)}`).join(", ");
-  // Existing rows whose frontmatter changed but whose content did not keep their vectors
-  // and summary: those columns stay out of the SET clause.
+  // Existing rows whose frontmatter changed but whose content did not keep their vectors,
+  // summary and keywords: those columns stay out of the SET clause.
+  // DIVERGENCE from lib/obsidian-compiler: the Elixir omits `keywords` from this exclusion
+  // list, so every note taking this path has its keywords overwritten with the frontmatter
+  // value, which is almost always absent and therefore NULL. Only regenerate_embeddings
+  // ever writes keywords, so an incremental run silently strips them from any note it does
+  // not regenerate. generate-search-index.ts weights keywords above spr_content, so the
+  // wipe degrades site search. The oracle is not fixed: it is being deleted.
   const updateFmOnly = keys
     .filter(
       (k) =>
         k !== "file_path" &&
         k !== "embeddings_gemini" &&
         k !== "embeddings_spr_custom" &&
-        k !== "spr_content"
+        k !== "spr_content" &&
+        k !== "keywords"
     )
     .map((k) => `${quoteIdent(k)} = EXCLUDED.${quoteIdent(k)}`)
     .join(", ");

--- a/test/duckdb-export.test.ts
+++ b/test/duckdb-export.test.ts
@@ -12,6 +12,9 @@
 
 import { describe, test, expect } from 'vitest';
 import {
+  Duck,
+  batchUpsertIntoDuckdb,
+  vaultTableDdl,
   jaroDistance,
   elixirFloat,
   graphemeLength,
@@ -242,6 +245,68 @@ describe('needsEmbeddingsUpdate (change-detection predicate)', () => {
         'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz',
       ),
     ).toBe(true);
+  });
+});
+
+describe('batchUpsertIntoDuckdb (frontmatter-only path)', () => {
+  const seed = async (): Promise<Duck> => {
+    const db = await Duck.open();
+    await db.exec(vaultTableDdl());
+    await db.exec(
+      `INSERT INTO vault (file_path, md_content, spr_content, keywords, title)
+       VALUES ('a.md', 'body', 'stored summary', ['alpha', 'beta'], 'Old')`,
+    );
+    return db;
+  };
+  const fileRow = (db: Duck) =>
+    db
+      .rows<{
+        title: string;
+        keywords: string[] | null;
+        spr_content: string | null;
+      }>(`SELECT title, keywords, spr_content FROM vault WHERE file_path = 'a.md'`)
+      .then(r => r[0]);
+
+  test('a changed frontmatter updates its own columns but carries keywords forward', async () => {
+    // The AI columns are only ever written by the regeneration path, so a note that skips
+    // regeneration must keep the stored keywords. The Elixir omits keywords from that
+    // carry-forward and blanks them on every incremental run; this port does not.
+    const db = await seed();
+    await batchUpsertIntoDuckdb(db, [
+      {
+        filePath: 'a.md',
+        mdContent: 'body',
+        frontmatter: { file_path: 'a.md', md_content: 'body', title: 'New' },
+        embeddingsUpdated: false,
+        frontmatterChanged: true,
+      },
+    ]);
+    const row = await fileRow(db);
+    expect(row.title).toBe('New');
+    expect(row.keywords).toEqual(['alpha', 'beta']);
+    expect(row.spr_content).toBe('stored summary');
+  });
+
+  test('the regeneration path still writes keywords', async () => {
+    const db = await seed();
+    await batchUpsertIntoDuckdb(db, [
+      {
+        filePath: 'a.md',
+        mdContent: 'body',
+        frontmatter: {
+          file_path: 'a.md',
+          md_content: 'body',
+          title: 'New',
+          keywords: ['gamma'],
+          spr_content: 'fresh summary',
+        },
+        embeddingsUpdated: true,
+        frontmatterChanged: true,
+      },
+    ]);
+    const row = await fileRow(db);
+    expect(row.keywords).toEqual(['gamma']);
+    expect(row.spr_content).toBe('fresh summary');
   });
 });
 


### PR DESCRIPTION
Finding 1 of #325: the reindexer wipes `keywords` on every incremental run. One line of `batch_upsert_into_duckdb` fixes it, plus a regression test.

The frontmatter-only upsert path (taken by a note whose frontmatter changed but whose content did not) excludes `spr_content` and both vector columns from its `SET` clause, but not `keywords`. Only the regeneration path ever writes `keywords`, and the frontmatter value is almost always absent, which serializes to `NULL`. So every note that path touches loses its keywords. `scripts/generate-search-index.ts` feeds `keywords` into MiniSearch at weight 1.7, above `spr_content` at 1.5, so the wipe has been quietly degrading site search.

## Before and after

Both runs start from the same `db/` snapshot and read the same vault (submodule at `dbe5b17`, 3141 files), `MEMO_EMBEDDINGS` unset, no AI key set, `--ignore-filter` so the whole vault is offered to the exporter.

To exercise the frontmatter-only path at scale, the snapshot is doctored once before both runs: `title` is prefixed with `STALE ` on the 1608 rows that carry keywords, a summary and both vectors. That is exactly the production trigger, a note whose frontmatter moved while its body did not. Both runs consume that same doctored snapshot.

| Check | Before | After |
|---|---|---|
| `keywords IS NULL` in the snapshot | 49 | 49 |
| `keywords IS NULL` in the output | **2372** | **796** |
| Rows whose keywords went non-null to null | **1576** | **0** |
| Rows whose keywords went null to non-null | 0 | 0 |
| Rows still carrying a `STALE ` title | 0 | 0 |

`STALE` reaching 0 in both runs confirms those rows did take the frontmatter-only update; the before run corrected their titles and blanked their keywords in the same statement. The remaining 796 nulls in the after run are the 49 pre-existing plus 747 notes new to the index, which have no keywords because no AI key was set.

## No collateral damage

Same row set in both outputs, 2746 rows, no row present in one and missing from the other.

```
before EXCEPT after  1576
after EXCEPT before  1576
```

Per-column mismatch count over all 42 columns, joined on `file_path`, `IS DISTINCT FROM` per column:

```
{"keywords": 1576}
```

Every other column reports 0. So the two parquets differ in `keywords` and nothing else.

Direction of those 1576 differences:

| Check | Count |
|---|---|
| Differing rows | 1576 |
| Of those, `keywords` null before | 1576 |
| Of those, `keywords` non-null after | 1576 |
| Of those, after value equals the snapshot value exactly | 1576 |
| Of those, after value differs from the snapshot value | 0 |
| Rows that gained keywords they did not have in the snapshot | 0 |

The fix preserves, it does not fabricate. Every difference is a row that kept the keywords it already had.

A second pair of runs on the plain incremental path (no `--ignore-filter`, 51 files selected, none of them an existing row taking the frontmatter-only path) is byte-identical before and after: `EXCEPT` is 0 in both directions. The change is inert wherever that path is not taken.

## Deliberate divergence from the Elixir

`lib/obsidian-compiler/` has the same bug and is **not** fixed here. It is kept only as the parity oracle for #325 and is slated for deletion, so teaching it new behaviour buys nothing and would invalidate nothing. The divergence is marked `DIVERGENCE:` at `batch_upsert_into_duckdb` and listed in the file header next to the other deliberate scope edges. Anyone re-running an oracle comparison after this lands should expect `keywords` to differ on exactly the rows that took the frontmatter-only path, and only that column.

## Test

`test/duckdb-export.test.ts` gains a `batchUpsertIntoDuckdb` group that seeds an in-memory DuckDB row with keywords and a summary, then runs a frontmatter-only upsert and asserts the title updated while `keywords` and `spr_content` survived. A sibling case asserts the regeneration path still writes `keywords`, so the exclusion cannot be widened into a silent no-write. Negative control: removing the one-line exclusion fails the first case with `expected ["alpha","beta"], received null`.

`batchUpsertIntoDuckdb`, `Duck` and a new `vaultTableDdl` helper (extracted from the branch it already lived on inside `setupDatabase`) are exported for the test.

`npx tsc --noEmit` is clean apart from the pre-existing `public/content/aliases.json` error that is also on `main`. `pnpm exec vitest run` is 127 passed across 11 files.

https://claude.ai/code/session_013TRBs7f8CFixZJviYX8Z7P
