### PR TITLE
feat(ci): alert Discord when the Pages publish fails

### DIFF
--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -97,3 +97,18 @@ jobs:
           GIT_FORCE_HTTPS: '1'
           SKIP_REINDEX: ${{ inputs.skip_reindex && '1' || '0' }}
         run: bash scripts/build-and-deploy.sh
+
+      # This is the only publish path, so a silent failure means the site
+      # serves stale content until someone notices by hand. Failure only:
+      # the deploy runs on every push to main, so a success ping is noise.
+      # Same action + webhook the retired backup.yml / dispatch.yml used.
+      - name: Notify Discord on Failure
+        if: failure()
+        uses: sarisia/actions-status-discord@v1
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          title: '❌ Pages Publish Failed'
+          description: |
+            memo.d.foundation did not publish. The site is serving stale content until this is fixed.
+            Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          color: 0xff0000


### PR DESCRIPTION
## Why

`publish-pages.yml` is now the single path that deploys the site, and it had no failure notification. The two workflows that carried Discord alarms, `backup.yml` and `dispatch.yml`, were retired in #327.

This is not hypothetical. This repo's CI sat broken for roughly ten months and nobody noticed. A silent deploy failure here means memo.d.foundation quietly serves stale content until a human happens to check.

## What

One step appended to the `publish` job:

- Fires on `if: failure()` only. The deploy runs on every push to `main`, so a success ping would be pure noise.
- `if: failure()` cannot swallow the job's real exit status: a passing notify step does not flip a failed job back to success.
- Includes the run URL (`github.server_url` / `github.repository` / `github.run_id`) so the alert is one click from the logs.

## Which webhook, and why

`secrets.DISCORD_WEBHOOK_URL`, not `DISCORD_WEBHOOK_URL_MEMO_LOGS`. Both exist as repo secrets (confirmed via `gh secret list`).

| Secret | Current use |
|---|---|
| `DISCORD_WEBHOOK_URL` | Every `sarisia/actions-status-discord` CI-status alert: `deploy-arweave.yml`, `add-mint-post.yml`, `generate-redirects.yml`, plus both retired workflows |
| `DISCORD_WEBHOOK_URL_MEMO_LOGS` | Content and monitoring reports from custom scripts: `memo-nft-report.yml`, `monitor-vault-parquet.yml` |

A deploy-failure alarm is CI status, not a memo log, so it belongs on the same channel as the other CI alarms. It also matches the pattern the deleted workflows used, which was the explicit goal.

## Verification

```
$ yq '.' .github/workflows/publish-pages.yml   # parses clean
$ yq '.jobs.publish.steps[-1] | {"name": .name, "if": .if, "uses": .uses, "webhook": .with.webhook}'
name: Notify Discord on Failure
if: failure()
uses: sarisia/actions-status-discord@v1
webhook: ${{ secrets.DISCORD_WEBHOOK_URL }}
```

The job stays gated behind `vars.PAGES_PUBLISH_ENABLED == 'true'`, so a skipped job never reaches the notify step.

https://claude.ai/code/session_013TRBs7f8CFixZJviYX8Z7P
