### PR TITLE
fix(ci): retry transient Cloudflare API failures in the deploy

### DIFF
--- a/scripts/build-and-deploy.sh
+++ b/scripts/build-and-deploy.sh
@@ -46,6 +46,25 @@ stage() {
   echo "=== $* ==="
 }
 
+# The Cloudflare API returns transient 5xx. A single 502 on one R2 put reds a
+# 15-minute run whose Pages deploy already succeeded, so retry the idempotent
+# single-shot calls instead of paying for a full rebuild.
+retry() {
+  local attempt=1 max=3
+  while true; do
+    if "$@"; then
+      return 0
+    fi
+    if [ "$attempt" -ge "$max" ]; then
+      echo "ERROR: '$*' failed after ${max} attempts." >&2
+      return 1
+    fi
+    echo "attempt ${attempt}/${max} failed, retrying in $((attempt * 10))s: $*" >&2
+    sleep $((attempt * 10))
+    attempt=$((attempt + 1))
+  done
+}
+
 require_env() {
   local name
   for name in "$@"; do
@@ -136,7 +155,7 @@ deploy_pages() {
 r2_put() {
   local src="$1" key="$2" content_type="$3" prefix
   for prefix in "derived/${DEPLOY_COMMIT_SHA}" "derived/latest"; do
-    npx wrangler@4 r2 object put "${R2_BUCKET}/${prefix}/${key}" \
+    retry npx wrangler@4 r2 object put "${R2_BUCKET}/${prefix}/${key}" \
       --file "$src" --content-type "$content_type" --remote
   done
 }
@@ -162,7 +181,7 @@ EOF
 # The database id is resolved from the name, so no extra variable is needed.
 upload_to_d1() {
   local database_id
-  database_id=$(npx wrangler@4 d1 info "$D1_DATABASE_NAME" --json | jq -r '.uuid')
+  database_id=$(retry npx wrangler@4 d1 info "$D1_DATABASE_NAME" --json | jq -r '.uuid')
   if [ -z "$database_id" ] || [ "$database_id" = "null" ]; then
     echo "ERROR: could not resolve the D1 database id for ${D1_DATABASE_NAME}." >&2
     exit 1
@@ -195,4 +214,7 @@ main() {
   stage "Done, deployed ${DEPLOY_COMMIT_SHA}"
 }
 
-main "$@"
+# Sourced (by test/build-and-deploy.test.ts) the file only defines functions.
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  main "$@"
+fi

--- a/test/build-and-deploy.test.ts
+++ b/test/build-and-deploy.test.ts
@@ -1,0 +1,55 @@
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+// The R2 and D1 stages sit after a ~15-minute build, so a single transient
+// Cloudflare 502 used to red a run whose Pages deploy had already succeeded.
+// retry() is what absorbs that. The script guards `main` behind a
+// BASH_SOURCE check so this can source it and exercise the function alone.
+const SCRIPT = path.join(__dirname, '..', 'scripts', 'build-and-deploy.sh');
+
+function run(body: string) {
+  // `sleep` is stubbed out so the backoff does not slow the suite down.
+  const script = [
+    'set -euo pipefail',
+    `source ${JSON.stringify(SCRIPT)}`,
+    'sleep() { :; }',
+    body,
+  ].join('\n');
+  try {
+    const stdout = execFileSync('bash', ['-c', script], { encoding: 'utf-8' });
+    return { code: 0, stdout, stderr: '' };
+  } catch (err) {
+    const e = err as { status: number; stdout: string; stderr: string };
+    return { code: e.status, stdout: e.stdout, stderr: e.stderr };
+  }
+}
+
+describe('scripts/build-and-deploy.sh retry()', () => {
+  it('succeeds once the command stops failing', () => {
+    const result = run(
+      [
+        'attempts=0',
+        'flaky() { attempts=$((attempts + 1)); [ "$attempts" -ge 3 ]; }',
+        'retry flaky',
+        'echo "attempts=$attempts"',
+      ].join('\n'),
+    );
+    expect(result.code).toBe(0);
+    expect(result.stdout).toMatch(/attempts=3/);
+  });
+
+  it('gives up with a non-zero exit after the attempt cap', () => {
+    const result = run(
+      ['always_fails() { return 1; }', 'retry always_fails'].join('\n'),
+    );
+    expect(result.code).toBe(1);
+    expect(result.stderr).toMatch(/failed after 3 attempts/);
+  });
+
+  it('passes the command stdout through untouched', () => {
+    const result = run(['retry echo hello-from-retry'].join('\n'));
+    expect(result.code).toBe(0);
+    expect(result.stdout).toMatch(/hello-from-retry/);
+  });
+});


### PR DESCRIPTION
## What broke

Run [31642682397](https://github.com/dwarvesf/memo.d.foundation/actions/runs/31642682397) (merge of #327) failed. The failure is **not** a build regression from #323/#327.

Ordering from the log:

| Time | Event |
|---|---|
| 21:39:54 | `next build` finishes. `Module not found: styled-jsx/style.js` is 1 of **9 Turbopack warnings**, non-fatal |
| 21:41 | RSS, 404, redirect parity all pass |
| 21:43:48 | `✨ Deployment complete!` Pages deploy **succeeded** |
| 21:43:55 | R2 stage starts, `db/vault.parquet` uploads to both prefixes |
| 21:44:11 | `wrangler r2 object put .../search-index.json` returns **Cloudflare api-gateway 502 Bad Gateway**, `set -e` kills the job |

The same `search-index.json` object uploaded fine at 21:14 in run 31640908895, same file, same token. The 502 is transient Cloudflare infrastructure.

## Hypotheses ruled out

- **`--no-frozen-lockfile` vs `--frozen-lockfile`**: the pre-#327 workflow used `pnpm install --no-frozen-lockfile` too (`git show 19e7853:.github/workflows/publish-pages.yml`). No change. CI also logged `Lockfile is up to date, resolution step is skipped`, and `pnpm install --frozen-lockfile` passes locally.
- **`packageManager` pin mismatch**: `package.json` has no `packageManager` field.
- **styled-jsx**: a warning. The build completed and produced the full route table.

## The fix

`retry()` around the idempotent single-shot wrangler calls: the six R2 puts and the D1 id lookup. 3 attempts, linear backoff. Those stages sit after a ~15-minute build, so one unretried 5xx costs a full rebuild of work that already shipped.

`main` is now guarded by a `BASH_SOURCE` check so the test can source the script and exercise `retry()` alone.

## Verification

| Check | Result |
|---|---|
| `bash -n scripts/build-and-deploy.sh` | pass |
| `shellcheck scripts/build-and-deploy.sh` | clean |
| `yq '.' .github/workflows/publish-pages.yml` | parses |
| `pnpm install --frozen-lockfile` | pass, pnpm 11.20.0 |
| `pnpm exec vitest run` | 13 files, 132 tests, all pass |
| `npx tsc --noEmit` | only the pre-existing `public/content/aliases.json` error, also on main |
| Negative control | set `max=1` in `retry()`, 2 of the 3 new tests fail; restored, tree clean |

## Still broken, out of scope

These log-and-continue, they do not fail the build, and they are pre-existing:

| Error | Cause |
|---|---|
| `Error generating pageviews: API call failed with status: 401` | `PLAUSIBLE_API_TOKEN` invalid or missing |
| `prompts/prompts.parquet does not exist in bucket df-landing-zone` | GCS reads rely on Google ADC that CI does not provide |
| `profiles/contributors.parquet does not exist in bucket df-landing-zone` | same |

Their downstream `ENOENT contributors.json` and `No files found ... prompts.parquet` messages are consequences, not separate faults.