### PR TITLE
chore(ci): bump actions to node24 runtimes

### DIFF
--- a/.github/workflows/add-mint-post.yml
+++ b/.github/workflows/add-mint-post.yml
@@ -20,7 +20,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout contents repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           fetch-depth: 1
@@ -41,13 +41,13 @@ jobs:
           echo "files=$CHANGED_FILES" >> $GITHUB_OUTPUT
 
       - name: Install Pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10
           run_install: false
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: 'pnpm'

--- a/.github/workflows/deploy-arweave.yml
+++ b/.github/workflows/deploy-arweave.yml
@@ -20,7 +20,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout contents repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           fetch-depth: 1
@@ -41,13 +41,13 @@ jobs:
           echo "files=$CHANGED_FILES" >> $GITHUB_OUTPUT
 
       - name: Install Pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10
           run_install: false
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: 'pnpm'

--- a/.github/workflows/generate-redirects.yml
+++ b/.github/workflows/generate-redirects.yml
@@ -20,25 +20,25 @@ jobs:
       contents: write
     steps:
       - name: Checkout contents repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           fetch-depth: 1
 
       - name: Get changed files from Memo
         id: changed-files
-        uses: tj-actions/changed-files@v46.0.5
+        uses: tj-actions/changed-files@v47.0.6
         with:
           separator: ','
 
       - name: Install PNPM
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10
           run_install: false
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: 'pnpm'
@@ -46,7 +46,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile
 
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v8
         if: steps.changed-files.outputs.all_changed_files != ''
         id: normalize-paths
         with:

--- a/.github/workflows/memo-nft-report.yml
+++ b/.github/workflows/memo-nft-report.yml
@@ -26,15 +26,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'pnpm'
@@ -95,7 +95,7 @@ jobs:
 
       - name: Upload failure logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: nft-report-failure-logs
           path: |

--- a/.github/workflows/monitor-vault-parquet.yml
+++ b/.github/workflows/monitor-vault-parquet.yml
@@ -26,15 +26,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'pnpm'
@@ -75,7 +75,7 @@ jobs:
 
       - name: Upload monitoring results
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: monitoring-failure-logs
           path: |
@@ -90,17 +90,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'pnpm'

--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -65,7 +65,7 @@ jobs:
       LANG: C.UTF-8
     steps:
       - name: Checkout contents repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           fetch-depth: 1
@@ -74,12 +74,12 @@ jobs:
       # both compilers are TypeScript now and reach DuckDB through
       # @duckdb/node-api, so the runner needs nothing else.
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: 11.6.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '23'
           cache: pnpm


### PR DESCRIPTION
## Why

GitHub warns that Node.js 20 is deprecated and force-runs those actions on Node 24. The warning comes from each action's own `runs.using` declaration in its `action.yml`, not from the `node-version` we build with, so bumping `setup-node`'s input does nothing. The fix is a major-version bump per action.

## What changed

| Action | Old | New | Why this major |
|---|---|---|---|
| `actions/checkout` | v4 | v5 | first major declaring node24 |
| `actions/setup-node` | v4 | v5 | first major declaring node24 |
| `pnpm/action-setup` | v4 | v5 | first major declaring node24 |
| `actions/upload-artifact` | v4 | v6 | v5 still declares node20, v6 is the first that does not |
| `actions/github-script` | v7 | v8 | first major declaring node24 |
| `tj-actions/changed-files` | v46.0.5 | v47.0.6 | v46 declares node20, v47 declares node24; exact-version pin kept |

Left alone on purpose:

| Action | Version | Reason |
|---|---|---|
| `sarisia/actions-status-discord` | v1 | already declares node24 |
| `./.github/actions/git-commit-push` | local | composite action, no node runtime |

Every bump lands on the LOWEST major that declares node24. `checkout`, `setup-node`, `pnpm/action-setup`, `upload-artifact` and `github-script` differ from their previous major only in `runs.using` (`setup-node` also gains one new optional input); `changed-files` v47 adds three optional inputs and one output on top of the runtime change. No existing workflow input or output changed.

## Conservative choices, given the pipeline only just went green

- **`actions/checkout` stops at v5.** v6 rewrites how credentials persist, which is exactly what the submodule commit-and-push flow depends on, and v7 blocks fork-PR checkout under `pull_request_target`. v5's release notes are the node24 runtime and nothing else, and the `action.yml` diff confirms it: one line.
- **`actions/setup-node` v5 auto-caching does not fire.** v5 enables caching automatically when `package.json` declares a `packageManager` field. Every `setup-node` step here already passes an explicit `cache: 'pnpm'`, which takes the first branch in the action's own logic, and the root `package.json` declares no `packageManager`. Caching behaviour is unchanged.
- The `submodules: recursive` checkouts keep their existing inputs untouched.

## Runner compatibility

Node 24 actions need Actions runner 2.327.1 or newer. Every job here runs on GitHub-hosted `ubuntu-latest`, which is well past that.

## Verification

- Every `uses:` ref resolved against its upstream `action.yml`: all report `runs.using: node24`. Negative control against `origin/main`: six of seven report node20.
- `yq '.'` parses all six touched workflows.
- `actionlint` on the same six: only pre-existing SC2086 shellcheck warnings, no action-reference error.

## Not merged

Leaving the merge to you, and deliberately separate from the matching foundation-workers PR (dwarvesf/foundation-workers#464) so one can land without the other.
