### PR TITLE
refactor(nav): fetch directory tree once instead of per-page props

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ run:
 	@pnpm run generate-pageviews
 	@pnpm run fetch-prompts
 	@pnpm run fetch-contributors
+	@pnpm run generate-directory-tree
 	@pnpm run dev
 
 duckdb-export:

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "generate-redirects-map": "tsx scripts/generate-redirects-map.ts",
     "generate-shorten-map": "tsx scripts/generate-shorten-map.ts",
     "generate-menu": "tsx scripts/generate-menu.ts",
+    "generate-directory-tree": "tsx scripts/generate-directory-tree.ts",
     "generate-backlinks": "tsx scripts/generate-backlinks.ts",
     "generate-summary": "tsx scripts/generate-summary.ts",
     "generate-nginx-conf": "tsx scripts/generate-nginx-redirect-map.ts",

--- a/scripts/generate-directory-tree.ts
+++ b/scripts/generate-directory-tree.ts
@@ -1,0 +1,26 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { getDirectoryTree } from '../src/lib/content/utils.js';
+
+// Emits the sidebar nav tree as a standalone static asset. The client fetches it
+// once instead of every page inlining a copy into its props.
+const outputPath = path.join(
+  process.cwd(),
+  'public/content/directory-tree.json',
+);
+
+async function main() {
+  const directoryTree = await getDirectoryTree();
+  await fs.mkdir(path.dirname(outputPath), { recursive: true });
+  await fs.writeFile(outputPath, JSON.stringify(directoryTree), 'utf-8');
+
+  const { size } = await fs.stat(outputPath);
+  console.log(
+    `Directory tree written to ${outputPath} (${(size / 1024).toFixed(1)} KB)`,
+  );
+}
+
+main().catch(error => {
+  console.error('Error generating directory tree:', error);
+  process.exit(1);
+});

--- a/scripts/memo-build.ts
+++ b/scripts/memo-build.ts
@@ -13,6 +13,8 @@ const commands = [
   'pnpm run fetch-contributors',
   'pnpm run generate-static-paths',
   'pnpm run generate-search-index',
+  // Must run before `next build` so the emitted JSON is copied out of public/.
+  'pnpm run generate-directory-tree',
   'next build',
   'pnpm run generate-rss',
   'pnpm run copy-404',

--- a/src/components/layout/ContributorLayout.tsx
+++ b/src/components/layout/ContributorLayout.tsx
@@ -7,6 +7,7 @@ import Footer from './Footer';
 import DirectoryTree from './DirectoryTree';
 import { IMetadata, ITocItem, ContributorLayoutPageProps } from '@/types';
 import { useLayoutContext, withLayoutContext } from '@/contexts/layout';
+import { useDirectoryTree } from '@/contexts/directory-tree';
 import ImageZoomProvider from '../image/ImageZoomProvider';
 import { SearchProvider } from '../search';
 import { useScrollToTopOnRouteChange } from '@/hooks/useScrollToTopOnRouteChange';
@@ -27,9 +28,9 @@ function ContributorLayout({
   description = 'Knowledge sharing platform for Dwarves Foundation',
   image,
   metadata,
-  directoryTree,
   searchIndex,
 }: ContributorLayoutProps) {
+  const directoryTree = useDirectoryTree();
   const { theme, toggleTheme } = useThemeContext();
 
   const { readingMode } = useLayoutContext();

--- a/src/components/layout/RootLayout.tsx
+++ b/src/components/layout/RootLayout.tsx
@@ -8,6 +8,7 @@ import DirectoryTree from './DirectoryTree';
 import { IMetadata, ITocItem, RootLayoutPageProps } from '@/types';
 import RightSidebar from './RightSidebar';
 import { useLayoutContext, withLayoutContext } from '@/contexts/layout';
+import { useDirectoryTree } from '@/contexts/directory-tree';
 import TableOfContents from './TableOfContents';
 import ImageZoomProvider from '../image/ImageZoomProvider';
 import { SearchProvider } from '../search';
@@ -48,13 +49,13 @@ function RootLayout({
   image,
   metadata,
   tocItems,
-  directoryTree,
   searchIndex,
   hideRightSidebar = false,
   fullWidth = false,
   mainClassName = '',
   // pinnedNotes and tags are no longer used directly by RootLayout
 }: RootLayoutProps) {
+  const directoryTree = useDirectoryTree();
   const { theme, toggleTheme } = useThemeContext();
   const { readingMode } = useLayoutContext();
   const scrollContainerRef = React.useRef<HTMLDivElement>(null);

--- a/src/components/memo/TagsMarquee.tsx
+++ b/src/components/memo/TagsMarquee.tsx
@@ -2,18 +2,16 @@ import { Marquee } from '../ui/marquee';
 import Tag from '../ui/tag';
 import { ITreeNode } from '@/types';
 import { useMemo } from 'react';
+import { useDirectoryTree } from '@/contexts/directory-tree';
 
-interface TagsMarqueeProps {
-  directoryTree: Record<string, ITreeNode>;
-}
-
-function TagsMarquee(props: TagsMarqueeProps) {
-  const { directoryTree } = props;
+// Rendered from vault MDX, which still passes a `directoryTree` prop. The real
+// tree comes from context; the prop is ignored.
+function TagsMarquee() {
+  const directoryTree = useDirectoryTree();
   const tags = useMemo(() => {
-    if (!directoryTree) return [];
-    const tagsNode = directoryTree['/tags'].children;
+    const tagsNode = directoryTree?.['/tags']?.children;
 
-    if (!tagsNode) return []; // Add this check as well, just in case children is null/undefined
+    if (!tagsNode) return [];
 
     return Object.entries(tagsNode).sort(([a], [b]) => a.localeCompare(b));
   }, [directoryTree]);

--- a/src/contexts/directory-tree.tsx
+++ b/src/contexts/directory-tree.tsx
@@ -1,0 +1,80 @@
+import { ITreeNode } from '@/types';
+import {
+  createContext,
+  PropsWithChildren,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
+
+export type DirectoryTree = Record<string, ITreeNode>;
+
+export const DIRECTORY_TREE_PATH = '/content/directory-tree.json';
+
+// The nav tree is a few hundred KB and byte-identical on every page. Shipping it
+// through page props inlined a copy into every HTML file and every _next/data
+// twin. It is now one static asset the browser fetches and caches once.
+let cachedTree: DirectoryTree | undefined;
+let inflight: Promise<DirectoryTree> | undefined;
+
+// The asset path is stable across builds, so pin the request to the build id.
+// A new deploy busts the cache; a repeat visit on the same build reuses it.
+function directoryTreeUrl(): string {
+  const nextData = (
+    window as unknown as { __NEXT_DATA__?: { buildId?: string } }
+  ).__NEXT_DATA__;
+  return nextData?.buildId
+    ? `${DIRECTORY_TREE_PATH}?v=${nextData.buildId}`
+    : DIRECTORY_TREE_PATH;
+}
+
+function loadDirectoryTree(): Promise<DirectoryTree> {
+  if (!inflight) {
+    inflight = fetch(directoryTreeUrl())
+      .then(response => {
+        if (!response.ok) {
+          throw new Error(`${response.status} ${response.statusText}`);
+        }
+        return response.json() as Promise<DirectoryTree>;
+      })
+      .then(tree => {
+        cachedTree = tree;
+        return tree;
+      })
+      .catch(error => {
+        console.error('Error fetching directory tree:', error);
+        // Drop the settled promise so a later mount can retry.
+        inflight = undefined;
+        return {} as DirectoryTree;
+      });
+  }
+  return inflight;
+}
+
+const DirectoryTreeContext = createContext<DirectoryTree | undefined>(
+  undefined,
+);
+
+export const DirectoryTreeProvider = ({ children }: PropsWithChildren) => {
+  const [tree, setTree] = useState<DirectoryTree | undefined>(cachedTree);
+
+  useEffect(() => {
+    if (tree) return;
+    let active = true;
+    loadDirectoryTree().then(loaded => {
+      if (active) setTree(loaded);
+    });
+    return () => {
+      active = false;
+    };
+  }, [tree]);
+
+  return (
+    <DirectoryTreeContext.Provider value={tree}>
+      {children}
+    </DirectoryTreeContext.Provider>
+  );
+};
+
+// Undefined until the fetch resolves. Every consumer already handles a missing tree.
+export const useDirectoryTree = () => useContext(DirectoryTreeContext);

--- a/src/lib/content/paths.ts
+++ b/src/lib/content/paths.ts
@@ -1,4 +1,4 @@
-import { memoize } from 'lodash';
+import memoize from 'lodash/memoize.js';
 import path from 'path';
 import {
   getAllMarkdownFiles,

--- a/src/lib/content/tags-utils.ts
+++ b/src/lib/content/tags-utils.ts
@@ -2,7 +2,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import { IMemoItem } from '@/types';
 import { getAllMarkdownContents } from './memo';
-import { memoize } from 'lodash';
+import memoize from 'lodash/memoize.js';
 import { uppercaseSpecialWords } from '../utils';
 
 interface TagCount {

--- a/src/lib/content/utils.ts
+++ b/src/lib/content/utils.ts
@@ -4,10 +4,9 @@ import {
   ITreeNode,
   MenuFilePath,
   NestedMenuPathTree,
-  RootLayoutPageProps,
 } from '@/types';
 import fs from 'fs/promises'; // Use promises version for async file reading
-import { memoize } from 'lodash';
+import memoize from 'lodash/memoize.js';
 import path from 'path'; // Import path module
 import { slugToTitle, uppercaseSpecialWords } from '../utils';
 import { formatContentPath } from '../utils/path-utils'; // Import formatContentPath from path-utils
@@ -347,14 +346,20 @@ const appendTagsCount = memoize((tags: string[], memos: IMemoItem[]) => {
     .sort((a, b) => b.count - a.count); // Sort by count in descending order
 });
 
-const CACHED_ROOT_LAYOUT_PAGE_PROPS_KEY = 'rootLayoutPageProps';
+const CACHED_DIRECTORY_TREE_KEY = 'directoryTree';
 
-export async function getRootLayoutPageProps(): Promise<RootLayoutPageProps> {
-  const CACHED_ROOT_LAYOUT_PAGE_PROPS = memoryCache.get<RootLayoutPageProps>(
-    CACHED_ROOT_LAYOUT_PAGE_PROPS_KEY,
+/**
+ * Builds the sidebar nav tree. The result is identical for every page, so it is
+ * written once to `public/content/directory-tree.json` by
+ * `scripts/generate-directory-tree.ts` and fetched by the client, instead of
+ * being inlined into each page's props.
+ */
+export async function getDirectoryTree(): Promise<Record<string, ITreeNode>> {
+  const CACHED_DIRECTORY_TREE = memoryCache.get<Record<string, ITreeNode>>(
+    CACHED_DIRECTORY_TREE_KEY,
   );
-  if (CACHED_ROOT_LAYOUT_PAGE_PROPS) {
-    return CACHED_ROOT_LAYOUT_PAGE_PROPS;
+  if (CACHED_DIRECTORY_TREE) {
+    return CACHED_DIRECTORY_TREE;
   }
 
   let menuData: Record<string, GroupedPath> = {};
@@ -424,12 +429,7 @@ export async function getRootLayoutPageProps(): Promise<RootLayoutPageProps> {
     '', // Start with empty currentPath
     staticJSONPaths,
   );
-  // console.log({ directoryTree, pinnedNotes, tags }); // Keep or remove logging as needed
 
-  const rootLayoutPageProps: RootLayoutPageProps = {
-    directoryTree,
-  };
-
-  memoryCache.set(CACHED_ROOT_LAYOUT_PAGE_PROPS_KEY, rootLayoutPageProps);
-  return rootLayoutPageProps;
+  memoryCache.set(CACHED_DIRECTORY_TREE_KEY, directoryTree);
+  return directoryTree;
 }

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,16 +1,13 @@
 import React from 'react';
 import { RootLayout } from '@/components';
-import { getRootLayoutPageProps } from '@/lib/content/utils';
 import { RootLayoutPageProps } from '@/types';
 import { GetStaticProps } from 'next';
 import Link from 'next/link';
 
 export const getStaticProps: GetStaticProps = async () => {
   try {
-    const layoutProps = await getRootLayoutPageProps();
-
     return {
-      props: layoutProps,
+      props: {},
     };
   } catch (error) {
     console.error('Error in getStaticProps:', error);

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -7,10 +7,7 @@ import fs from 'fs/promises';
 // Import utility functions
 import { getMarkdownContent } from '../lib/content/markdown';
 import { getAllMarkdownContents, isPublished } from '@/lib/content/memo';
-import {
-  getRootLayoutPageProps,
-  getServerSideRedirectPath,
-} from '@/lib/content/utils';
+import { getServerSideRedirectPath } from '@/lib/content/utils';
 import { slugToTitle } from '@/lib/utils';
 import { getFirstMemoImage } from '@/components/memo/utils';
 
@@ -96,9 +93,6 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 
     const canonicalSlug = targetPath.split('/').filter(Boolean);
 
-    // Pass includeContent: false as we only need metadata for layout props
-    const layoutProps = await getRootLayoutPageProps();
-
     // --- Check for MDX files first ---
     // (Variable names must not conflict with those above)
     const mdxFilePath2 =
@@ -170,7 +164,6 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 
       return {
         props: {
-          ...layoutProps,
           mdxSource,
           frontmatter,
           slug,
@@ -267,7 +260,6 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 
         return {
           props: {
-            ...layoutProps,
             slug,
             childMemos: allMemos,
             isListPage: true,
@@ -378,7 +370,6 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     };
     return {
       props: {
-        ...layoutProps,
         content,
         frontmatter: JSON.parse(JSON.stringify(frontmatter)),
         slug,
@@ -403,7 +394,6 @@ export default function ContentPage({
   backlinks,
   tocItems,
   metadata,
-  directoryTree,
   searchIndex,
   isListPage,
   isMdxPage,
@@ -539,11 +529,7 @@ export default function ContentPage({
   if (isListPage) {
     const title = slug.map(slugToTitle).join(' > ');
     return (
-      <RootLayout
-        title={title}
-        searchIndex={searchIndex}
-        directoryTree={directoryTree}
-      >
+      <RootLayout title={title} searchIndex={searchIndex}>
         <MemoList title={title} memos={childMemos || []} />
       </RootLayout>
     );
@@ -554,7 +540,6 @@ export default function ContentPage({
         title={frontmatter?.title}
         description={frontmatter?.description} // Use GitHub bio as description
         image={frontmatter?.image} // Use GitHub avatar as image
-        directoryTree={directoryTree}
         searchIndex={searchIndex}
       >
         <div className="content-wrapper">
@@ -577,7 +562,6 @@ export default function ContentPage({
         image={metadata?.image}
         tocItems={tocItems}
         metadata={metadata}
-        directoryTree={directoryTree}
         searchIndex={searchIndex}
       >
         <div className="content-wrapper">
@@ -601,11 +585,7 @@ export default function ContentPage({
   } else {
     // Handle case where content or frontmatter is undefined (shouldn't happen with fallback: false)
     return (
-      <RootLayout
-        title="Not Found"
-        directoryTree={directoryTree}
-        searchIndex={searchIndex}
-      >
+      <RootLayout title="Not Found" searchIndex={searchIndex}>
         <div>Page not found.</div>
       </RootLayout>
     );

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -4,6 +4,7 @@ import '@/styles/globals.css';
 import type { AppProps } from 'next/app';
 import { Toaster } from '@/components/ui/sonner';
 import { Web3Provider } from '@/contexts/Web3Provider';
+import { DirectoryTreeProvider } from '@/contexts/directory-tree';
 import { useEffect } from 'react';
 import { useRouter } from 'next/router';
 
@@ -39,8 +40,10 @@ export default function App({ Component, pageProps }: AppProps) {
   return (
     <ThemeProvider>
       <Web3Provider>
-        <Component {...pageProps} />
-        <Toaster position="top-center" />
+        <DirectoryTreeProvider>
+          <Component {...pageProps} />
+          <Toaster position="top-center" />
+        </DirectoryTreeProvider>
       </Web3Provider>
     </ThemeProvider>
   );

--- a/src/pages/all.tsx
+++ b/src/pages/all.tsx
@@ -1,7 +1,6 @@
 import { GetStaticProps } from 'next';
 import { RootLayout } from '../components';
 import { IMemoItemWithAuthors, RootLayoutPageProps } from '@/types';
-import { getRootLayoutPageProps } from '@/lib/content/utils';
 import { convertToMemoItems } from '@/lib/content/memo';
 import { queryDuckDB } from '@/lib/db/utils';
 import { getCompactContributorsFromContentJSON } from '@/lib/contributor';
@@ -13,7 +12,6 @@ interface AllPageProps extends RootLayoutPageProps {
 
 export const getStaticProps: GetStaticProps = async () => {
   try {
-    const layoutProps = await getRootLayoutPageProps();
     const queryFields = [
       'short_title',
       'title',
@@ -67,7 +65,6 @@ export const getStaticProps: GetStaticProps = async () => {
 
     return {
       props: {
-        ...layoutProps,
         allMemos,
       },
     };
@@ -81,16 +78,11 @@ export const getStaticProps: GetStaticProps = async () => {
   }
 };
 
-export default function All({
-  directoryTree,
-  searchIndex,
-  allMemos,
-}: AllPageProps) {
+export default function All({ searchIndex, allMemos }: AllPageProps) {
   return (
     <RootLayout
       title="Dwarves Memo - All Posts"
       description="All posts grouped by year and month"
-      directoryTree={directoryTree}
       searchIndex={searchIndex}
     >
       <div className="memo-content">

--- a/src/pages/contributor/[slug].tsx
+++ b/src/pages/contributor/[slug].tsx
@@ -6,7 +6,6 @@ import slugify from 'slugify';
 
 // Import utility functions
 import { convertToMemoItems, getAllMarkdownContents } from '@/lib/content/memo';
-import { getRootLayoutPageProps } from '@/lib/content/utils';
 import { queryDuckDB } from '@/lib/db/utils'; // Utility for DuckDB queries
 
 // Import components
@@ -356,8 +355,6 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
   try {
     const { slug: contributorSlug } = params as { slug: string };
 
-    const layoutProps = await getRootLayoutPageProps();
-
     // --- Fetch Contributor Name Casing (from Memos or infer from slug) ---
     const allMemos = await getAllMarkdownContents(); // Fetch all memos to find original name casing
     const originalContributorName =
@@ -615,7 +612,6 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 
     return {
       props: {
-        ...layoutProps,
         slug: contributorSlug, // Pass the original requested slug
         contributorName: originalContributorName,
         contributorProfile,
@@ -634,7 +630,6 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 
 export default function ContentPage({
   frontmatter,
-  directoryTree,
   searchIndex,
   contributorName,
   mdxSource,
@@ -649,7 +644,6 @@ export default function ContentPage({
       title={frontmatter?.title || `${contributorName}'s Profile`}
       description={frontmatter?.description || contributorProfile?.bio || ''} // Use GitHub bio as description
       image={frontmatter?.image || contributorProfile?.avatar} // Use GitHub avatar as image
-      directoryTree={directoryTree}
       searchIndex={searchIndex}
     >
       <div className="content-wrapper">

--- a/src/pages/contributor/index.tsx
+++ b/src/pages/contributor/index.tsx
@@ -3,7 +3,6 @@ import { GetStaticProps } from 'next';
 
 // Import utility functions
 import { getAllMarkdownContents, sortMemos } from '@/lib/content/memo';
-import { getRootLayoutPageProps } from '@/lib/content/utils';
 import { getCompactContributorsFromContentJSON } from '@/lib/contributor';
 
 import { RootLayoutPageProps } from '@/types';
@@ -51,7 +50,6 @@ function formatPathForUrl(filePath: string | null | undefined): string | null {
 export const getStaticProps: GetStaticProps = async () => {
   try {
     const allMemos = await getAllMarkdownContents();
-    const layoutProps = await getRootLayoutPageProps();
 
     const contributors = new Set<string>();
     const contributionCount: Record<string, number> = {};
@@ -122,7 +120,6 @@ export const getStaticProps: GetStaticProps = async () => {
 
     return {
       props: {
-        ...layoutProps,
         contributors: enrichedContributors,
         contributorLatestWork,
         contributionCount,
@@ -137,7 +134,6 @@ export const getStaticProps: GetStaticProps = async () => {
 
 export default function ContentPage({
   frontmatter,
-  directoryTree,
   searchIndex,
   contributorLatestWork,
   contributors,
@@ -149,7 +145,6 @@ export default function ContentPage({
       title={frontmatter?.title}
       description={frontmatter?.description} // Use GitHub bio as description
       image={frontmatter?.image} // Use GitHub avatar as image
-      directoryTree={directoryTree}
       searchIndex={searchIndex}
     >
       <div className="content-wrapper">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,7 +3,6 @@ import { GetStaticProps } from 'next';
 import { RootLayout } from '../components';
 import { IMemoItem, RootLayoutPageProps } from '@/types';
 
-import { getRootLayoutPageProps } from '@/lib/content/utils';
 import { convertToMemoItems } from '@/lib/content/memo';
 import { getMdxSource } from '@/lib/mdx';
 import path from 'path';
@@ -18,7 +17,6 @@ interface HomePageProps extends RootLayoutPageProps {
 
 export const getStaticProps: GetStaticProps = async () => {
   try {
-    const layoutProps = await getRootLayoutPageProps(); // Await the asynchronous function
     const queryFields = [
       'short_title',
       'title',
@@ -154,7 +152,9 @@ export const getStaticProps: GetStaticProps = async () => {
         teamMemos,
         changelogMemos,
         hiringMemos,
-        directoryTree: layoutProps.directoryTree,
+        // The vault's index.mdx still references this identifier when it renders
+        // <TagsMarquee />, which now reads the tree from context instead.
+        directoryTree: {},
         memosWithTags,
       },
     });
@@ -165,7 +165,6 @@ export const getStaticProps: GetStaticProps = async () => {
 
     return {
       props: {
-        ...layoutProps,
         mdxSource,
       },
     };
@@ -179,11 +178,7 @@ export const getStaticProps: GetStaticProps = async () => {
   }
 };
 
-export default function Home({
-  directoryTree,
-  searchIndex,
-  mdxSource,
-}: HomePageProps) {
+export default function Home({ searchIndex, mdxSource }: HomePageProps) {
   if (!mdxSource || 'error' in mdxSource) {
     // We already handle this in getStaticProps
     return null;
@@ -192,7 +187,6 @@ export default function Home({
     <RootLayout
       title="Dwarves Memo - Home"
       description="Knowledge sharing platform for Dwarves Foundation"
-      directoryTree={directoryTree}
       searchIndex={searchIndex}
     >
       <RemoteMdxRenderer mdxSource={mdxSource} />

--- a/src/pages/prompts/index.tsx
+++ b/src/pages/prompts/index.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { getRootLayoutPageProps } from '@/lib/content/utils';
 import { getPrompts } from '@/lib/prompts';
 import { IPromptItem, RootLayoutPageProps } from '@/types';
 import { GetStaticProps } from 'next';
@@ -31,10 +30,8 @@ interface PromptsPageProps extends RootLayoutPageProps {
  */
 export const getStaticProps: GetStaticProps<PromptsPageProps> = async () => {
   const prompts = await getPrompts();
-  const layoutProps = await getRootLayoutPageProps();
   return {
     props: {
-      ...layoutProps,
       prompts,
     },
   };
@@ -44,11 +41,7 @@ export const getStaticProps: GetStaticProps<PromptsPageProps> = async () => {
  * Prompts category page component
  * Displays a grid of prompt cards filtered by category
  */
-const PromptsPage: React.FC<PromptsPageProps> = ({
-  directoryTree,
-  searchIndex,
-  prompts,
-}) => {
+const PromptsPage: React.FC<PromptsPageProps> = ({ searchIndex, prompts }) => {
   const categoryRefs = useRef<{ [key: string]: HTMLDivElement | null }>({});
   const router = useRouter();
   const [isInitialLoadScrollHandled, setIsInitialLoadScrollHandled] =
@@ -200,7 +193,6 @@ const PromptsPage: React.FC<PromptsPageProps> = ({
   return (
     <RootLayout
       title="AI Prompts"
-      directoryTree={directoryTree}
       searchIndex={searchIndex}
       hideRightSidebar
       fullWidth

--- a/src/pages/tags/[slug].tsx
+++ b/src/pages/tags/[slug].tsx
@@ -5,7 +5,6 @@ import { GetStaticProps, GetStaticPaths } from 'next';
 
 // Import components
 import { IMemoItem, RootLayoutPageProps } from '@/types';
-import { getRootLayoutPageProps } from '@/lib/content/utils';
 import { filterMemo, getAllMarkdownContents } from '@/lib/content/memo';
 import { RootLayout } from '@/components';
 import Link from 'next/link';
@@ -54,7 +53,6 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
   try {
     const { slug } = params as { slug: string };
     const allMemos = await getAllMarkdownContents();
-    const layoutProps = await getRootLayoutPageProps();
 
     const normalizedSlug = slug.toLowerCase();
     if (!normalizedSlug) {
@@ -87,7 +85,6 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 
     return {
       props: {
-        ...layoutProps,
         slug,
         tag: originalTag, // Use the original case for display
         data: memos,
@@ -101,7 +98,6 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 
 export default function TagDetailPage({
   tag,
-  directoryTree,
   searchIndex,
   data,
 }: ContentPageProps) {
@@ -130,11 +126,7 @@ export default function TagDetailPage({
     return keys;
   }, [groupedMemos]);
   return (
-    <RootLayout
-      title={tag}
-      directoryTree={directoryTree}
-      searchIndex={searchIndex}
-    >
+    <RootLayout title={tag} searchIndex={searchIndex}>
       <div className="flex items-center">
         <div className="flex flex-col">
           <h1 className="-track-[0.5px] mb-5 pt-0 text-[35px] leading-[42px] font-semibold">

--- a/src/pages/tags/index.tsx
+++ b/src/pages/tags/index.tsx
@@ -3,7 +3,6 @@ import { GetStaticProps } from 'next';
 import Link from 'next/link';
 import React from 'react';
 import { getTagsWithCounts } from '@/lib/content/tags-utils';
-import { getRootLayoutPageProps } from '@/lib/content/utils';
 import { RootLayoutPageProps } from '@/types';
 import { truncate } from 'lodash';
 
@@ -19,7 +18,6 @@ interface TagsPageProps extends RootLayoutPageProps {
 export const getStaticProps: GetStaticProps<TagsPageProps> = async () => {
   try {
     const tagCounts = await getTagsWithCounts();
-    const layoutProps = await getRootLayoutPageProps();
 
     return {
       props: {
@@ -27,7 +25,6 @@ export const getStaticProps: GetStaticProps<TagsPageProps> = async () => {
           name: tag.name,
           count: tag.count.toString(), // Convert count to string as per requirement
         })),
-        ...layoutProps,
       },
     };
   } catch (error) {
@@ -40,9 +37,9 @@ export const getStaticProps: GetStaticProps<TagsPageProps> = async () => {
   }
 };
 
-const TagsPage = ({ tagCounts, directoryTree }: TagsPageProps) => {
+const TagsPage = ({ tagCounts }: TagsPageProps) => {
   return (
-    <RootLayout title="Tags" directoryTree={directoryTree}>
+    <RootLayout title="Tags">
       <div className="flex items-center">
         {tagCounts && tagCounts.length > 0 && (
           <div className="flex flex-col gap-4">

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -65,13 +65,13 @@ export interface ISearchResultItem {
   index?: number;
 }
 
+// The nav tree is no longer a page prop: it is fetched client-side once from
+// /content/directory-tree.json. See src/contexts/directory-tree.tsx.
 export interface RootLayoutPageProps {
-  directoryTree?: Record<string, ITreeNode>;
   searchIndex?: IMiniSearchIndex | null;
 }
 
 export interface ContributorLayoutPageProps {
-  directoryTree?: Record<string, ITreeNode>;
   searchIndex?: IMiniSearchIndex | null;
 }
 


### PR DESCRIPTION
## What

The sidebar nav tree (`directoryTree`) was built at build time and handed to every page through `getStaticProps`. It is byte-identical on every page, so:

- every HTML file inlined a ~268 KB copy into `__NEXT_DATA__`
- every `_next/data/<buildId>/<page>.json` twin carried the same copy again
- the homepage carried it **twice**, because `index.tsx` also injected it into the MDX scope for `<TagsMarquee />`

This PR emits the tree once as a static asset and has the client fetch it once.

## How

```
build                                     browser
-----                                     -------
generate-menu        -> menu.json
generate-directory-tree
  getDirectoryTree() -> public/content/directory-tree.json
                                 |
next build                       |  fetch once, cached, ?v=<buildId>
  pages ship NO tree in props    v
                          DirectoryTreeProvider (_app)
                                 |
                    +------------+------------+
                    |            |            |
                Sidebar    DirectoryTree  TagsMarquee
```

- `getRootLayoutPageProps()` becomes `getDirectoryTree()`, returning the tree instead of a props bag. Its only caller is now the new `scripts/generate-directory-tree.ts`, which runs before `next build` so the JSON is in `public/` when Next copies it into `out/`.
- New `DirectoryTreeProvider` in `_app.tsx` fetches `/content/directory-tree.json` once per session (module-level promise, so remounts and route changes reuse it). The URL carries `?v=<buildId>` so a deploy busts the cache while repeat visits on the same build hit cache.
- `RootLayout` / `ContributorLayout` / `TagsMarquee` read the tree from context. `Sidebar`, `MobileDrawer` and `DirectoryTree` keep their existing props and are unchanged.
- Ten pages drop the `getRootLayoutPageProps()` call and the `...layoutProps` spread.
- Three `import { memoize } from 'lodash'` become `import memoize from 'lodash/memoize.js'`. lodash is CJS and the package is `type: module`, so the named import breaks under Node ESM; the generator script imports this module graph directly. Behaviour is identical under webpack.

## Measurements

Full static export, 1152 pages, same vault snapshot before and after, paired by page path.

| Metric | Before | After | Delta |
|---|---:|---:|---:|
| total `out/` | 1563.4 MB | 983.0 MB | **-37.1%** |
| page HTML total | 626.5 MB | 325.1 MB | **-48.1%** |
| page HTML median | 544.9 KB | 277.0 KB | -49.2% |
| smallest page using the layout | 517.8 KB | 250.0 KB | -51.7% |
| largest page (`all.html`) | 1206.5 KB | 938.7 KB | -22.2% |
| `_next/data` total | 294.5 MB | 15.3 MB | **-94.8%** |
| `_next/data` median | 255.4 KB | 7.0 KB | -97.3% |

Every page that uses the layout drops exactly 267.8-267.9 KB. The homepage drops 558.7 KB (1083.0 KB -> 524.3 KB) because it carried the tree twice.

The one page with no change is `status.html` (209.4 KB before and after): it does not use `RootLayout`, so it never carried the tree. It was already the smallest page in the build, so the "smallest page" floor moved from 517.8 KB to 250.0 KB for real content pages.

## Verification

`npx tsc --noEmit` clean. `pnpm exec vitest run`: 13 files, 132 tests passing. `eslint`: 0 errors (17 pre-existing warnings, none in changed lines).

Rendering checked in headless Chrome against a local `serve` of both `out/` builds, sessionStorage cleared before each load (the sidebar remembers expanded folders):

| Page | Build | sidebar links | prefetches | tree fetch | console errors |
|---|---|---:|---:|---|---:|
| `/` | before | 25 | 2 | no | 1 |
| `/` | after | 25 | 2 | yes | 1 |
| `/updates/digest` | before | 245 | 5 | no | 0 |
| `/updates/digest` | after | 245 | 5 | yes | 0 |
| `/misc/tokenomics/governance-framework` | before | 43 | 16 | no | 0 |
| `/misc/tokenomics/governance-framework` | after | 43 | 16 | yes | 0 |
| `/updates` | before | 33 | 14 | no | 0 |
| `/updates` | after | 33 | 14 | yes | 0 |

Identical sidebar contents and identical prefetch counts, so **client-side route prefetch still works**. The one console error on `/` is React #418 (hydration text mismatch) and is **pre-existing**: it reproduces on the unmodified baseline build.

Client-side navigation: loaded `/misc/tokenomics/governance-framework`, clicked a sidebar link, landed on `/consulting/navigate/experiment` with the correct title, sidebar still populated, `directory-tree.json` requested exactly **once** across the whole session, no errors.

## Tradeoffs

**No-JS visitors.** Before, the server-rendered HTML contained the collapsed top level of the file tree: 25 links inside `<div id="sidebar">`. After, that container renders empty and fills in after hydration, so a JS-disabled visitor sees 25 fewer nav links. On the homepage they also lose the tag marquee (~156 tag links), which was rendered from the MDX-scope copy of the tree. Everything else a no-JS visitor had is unchanged: the icon-rail nav (Home, Consulting, Handbook, Playbook, Hiring, Changelog, Contributor, Prompts), page content, author and tag links, and the footer.

**First paint.** The sidebar arrives after hydration instead of in the HTML. The container is already laid out, so this is a fill-in rather than a reflow, and the payload is one cached request. Against that, every page is now roughly half the bytes it was.

## Notes, not fixed here

- `_next/data` twins are down to a 7.0 KB median, so most stop mattering. 438 of 1150 are still over 10 KB, driven by genuine page data rather than the nav tree: `all.json` 628.5 KB, `updates.json` 278.0 KB, `index.json` 247.6 KB.
- `index.html` still carries 247.7 KB of `__NEXT_DATA__` after this change, almost all of it `mdxSource.scope.memosWithTags` (248.2 KB). Same shape of problem, separate fix.
- The vault's `index.mdx` still writes `<TagsMarquee directoryTree={directoryTree} />`. The prop is ignored now, and `index.tsx` passes `{}` for the identifier so the MDX still evaluates. The vault line can be cleaned up separately in `dwarvesf/brainery`.

Local build used a vault checkout limited to git-tracked files, so it exported 1152 pages rather than the full production set, and `/research/*` was absent. Percentages are per-page ratios and paired by path, so they carry over; absolute totals scale with page count.
