### PR TITLE
refactor(home): fetch memos with tags once instead of per-page props

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ run:
 	@pnpm run fetch-prompts
 	@pnpm run fetch-contributors
 	@pnpm run generate-directory-tree
+	@pnpm run generate-memos-with-tags
 	@pnpm run dev
 
 duckdb-export:

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "generate-shorten-map": "tsx scripts/generate-shorten-map.ts",
     "generate-menu": "tsx scripts/generate-menu.ts",
     "generate-directory-tree": "tsx scripts/generate-directory-tree.ts",
+    "generate-memos-with-tags": "tsx scripts/generate-memos-with-tags.ts",
     "generate-backlinks": "tsx scripts/generate-backlinks.ts",
     "generate-summary": "tsx scripts/generate-summary.ts",
     "generate-nginx-conf": "tsx scripts/generate-nginx-redirect-map.ts",

--- a/scripts/generate-memos-with-tags.ts
+++ b/scripts/generate-memos-with-tags.ts
@@ -1,0 +1,26 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { getMemosWithTags } from '../src/lib/content/memos-with-tags.js';
+
+// Emits every tagged memo as a standalone static asset. The client fetches it
+// once instead of the homepage inlining a copy into its props.
+const outputPath = path.join(
+  process.cwd(),
+  'public/content/memos-with-tags.json',
+);
+
+async function main() {
+  const memosWithTags = await getMemosWithTags();
+  await fs.mkdir(path.dirname(outputPath), { recursive: true });
+  await fs.writeFile(outputPath, JSON.stringify(memosWithTags), 'utf-8');
+
+  const { size } = await fs.stat(outputPath);
+  console.log(
+    `Memos with tags written to ${outputPath} (${(size / 1024).toFixed(1)} KB)`,
+  );
+}
+
+main().catch(error => {
+  console.error('Error generating memos with tags:', error);
+  process.exit(1);
+});

--- a/scripts/memo-build.ts
+++ b/scripts/memo-build.ts
@@ -15,6 +15,10 @@ const commands = [
   'pnpm run generate-search-index',
   // Must run before `next build` so the emitted JSON is copied out of public/.
   'pnpm run generate-directory-tree',
+  // Needs contributors.json (fetch-contributors) and db/vault.parquet
+  // (duckdb-export, already run before this script). Must also run before
+  // `next build`.
+  'pnpm run generate-memos-with-tags',
   'next build',
   'pnpm run generate-rss',
   'pnpm run copy-404',

--- a/src/components/memo/MemoFilterList.tsx
+++ b/src/components/memo/MemoFilterList.tsx
@@ -1,18 +1,18 @@
-import { IMemoItem } from '@/types';
 import React, { useState } from 'react';
 import { cn } from '@/lib/utils';
 import Link from 'next/link';
 import { formatContentPath } from '@/lib/utils/path-utils';
 import { Avatar, AvatarImage } from '../ui/avatar';
 import Jdenticon from 'react-jdenticon';
+import { MemoWithTags } from '@/lib/content/memos-with-tags';
+import { useMemosWithTags } from '@/contexts/memos-with-tags';
 
 interface MemoFilterListProps {
   title: string;
-  all: (IMemoItem & { authorAvatars: string[] })[];
   filters?: string[];
 }
 
-function List({ data }: { data: (IMemoItem & { authorAvatars: string[] })[] }) {
+function List({ data }: { data: MemoWithTags[] }) {
   return (
     <div className="flex flex-col">
       {data.map(memo => (
@@ -62,7 +62,10 @@ function List({ data }: { data: (IMemoItem & { authorAvatars: string[] })[] }) {
   );
 }
 
-function MemoFilterList({ title, all, filters }: MemoFilterListProps) {
+// Rendered from vault MDX, which still passes an `all` prop sourced from the
+// mdxSource scope. The real data comes from context; the prop is ignored.
+function MemoFilterList({ title, filters }: MemoFilterListProps) {
+  const all = useMemosWithTags() ?? [];
   const [selectedFilter, setSelectedFilter] = useState<string | null>(null);
 
   return (

--- a/src/components/memo/WorthReading.tsx
+++ b/src/components/memo/WorthReading.tsx
@@ -4,6 +4,7 @@ import { BlocksIcon, BookOpenIcon, BrainIcon, SproutIcon } from 'lucide-react';
 import Link from 'next/link';
 import { format } from 'date-fns';
 import { cn } from '@/lib/utils';
+import { useMemosWithTags } from '@/contexts/memos-with-tags';
 
 interface BlockProps {
   title: string;
@@ -12,7 +13,6 @@ interface BlockProps {
 }
 
 interface WorthReadingProps {
-  memos: { title: string; tags: string[]; filePath: string; date: string }[];
   blocks: BlockProps[];
 }
 
@@ -33,7 +33,10 @@ const dummyTexts = [
   "I'm not sure why you're reading this",
 ];
 
-const WorthReading = ({ blocks, memos }: WorthReadingProps) => {
+// Rendered from vault MDX, which still passes a `memos` prop sourced from the
+// mdxSource scope. The real data comes from context; the prop is ignored.
+const WorthReading = ({ blocks }: WorthReadingProps) => {
+  const memos = useMemosWithTags() ?? [];
   return (
     <div className="relative flex flex-col">
       <h2>Worth Reading</h2>

--- a/src/contexts/memos-with-tags.tsx
+++ b/src/contexts/memos-with-tags.tsx
@@ -1,0 +1,78 @@
+import { MemoWithTags } from '@/lib/content/memos-with-tags';
+import {
+  createContext,
+  PropsWithChildren,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
+
+export const MEMOS_WITH_TAGS_PATH = '/content/memos-with-tags.json';
+
+// Every tagged memo, byte-identical for every visitor. Shipping it through page
+// props inlined a copy into the homepage's HTML and its _next/data twin. It is
+// now one static asset the browser fetches and caches once.
+let cachedMemos: MemoWithTags[] | undefined;
+let inflight: Promise<MemoWithTags[]> | undefined;
+
+// The asset path is stable across builds, so pin the request to the build id.
+// A new deploy busts the cache; a repeat visit on the same build reuses it.
+function memosWithTagsUrl(): string {
+  const nextData = (
+    window as unknown as { __NEXT_DATA__?: { buildId?: string } }
+  ).__NEXT_DATA__;
+  return nextData?.buildId
+    ? `${MEMOS_WITH_TAGS_PATH}?v=${nextData.buildId}`
+    : MEMOS_WITH_TAGS_PATH;
+}
+
+function loadMemosWithTags(): Promise<MemoWithTags[]> {
+  if (!inflight) {
+    inflight = fetch(memosWithTagsUrl())
+      .then(response => {
+        if (!response.ok) {
+          throw new Error(`${response.status} ${response.statusText}`);
+        }
+        return response.json() as Promise<MemoWithTags[]>;
+      })
+      .then(memos => {
+        cachedMemos = memos;
+        return memos;
+      })
+      .catch(error => {
+        console.error('Error fetching memos with tags:', error);
+        // Drop the settled promise so a later mount can retry.
+        inflight = undefined;
+        return [] as MemoWithTags[];
+      });
+  }
+  return inflight;
+}
+
+const MemosWithTagsContext = createContext<MemoWithTags[] | undefined>(
+  undefined,
+);
+
+export const MemosWithTagsProvider = ({ children }: PropsWithChildren) => {
+  const [memos, setMemos] = useState<MemoWithTags[] | undefined>(cachedMemos);
+
+  useEffect(() => {
+    if (memos) return;
+    let active = true;
+    loadMemosWithTags().then(loaded => {
+      if (active) setMemos(loaded);
+    });
+    return () => {
+      active = false;
+    };
+  }, [memos]);
+
+  return (
+    <MemosWithTagsContext.Provider value={memos}>
+      {children}
+    </MemosWithTagsContext.Provider>
+  );
+};
+
+// Undefined until the fetch resolves. Every consumer already handles a missing list.
+export const useMemosWithTags = () => useContext(MemosWithTagsContext);

--- a/src/lib/content/memos-with-tags.ts
+++ b/src/lib/content/memos-with-tags.ts
@@ -1,0 +1,60 @@
+import { queryDuckDB } from '@/lib/db/utils';
+import { getCompactContributorsFromContentJSON } from '@/lib/contributor';
+
+export interface MemoWithTags {
+  title: string;
+  tags: string[];
+  filePath: string;
+  date: string;
+  authors: string[];
+  authorAvatars: (string | null)[];
+}
+
+/**
+ * Every tagged memo, newest first. Homepage-only, feeds the "Worth Reading" and
+ * "Latest memos" sections. Result is identical for every visitor, so it is
+ * written once to `public/content/memos-with-tags.json` by
+ * `scripts/generate-memos-with-tags.ts` and fetched by the client, instead of
+ * being inlined into the homepage's props.
+ */
+export async function getMemosWithTags(): Promise<MemoWithTags[]> {
+  const userProfiles = await getCompactContributorsFromContentJSON();
+  const avatarMap = userProfiles.reduce(
+    (acc, profile) => {
+      if (profile.avatar) {
+        acc[profile.username] = profile.avatar;
+      }
+      return acc;
+    },
+    {} as Record<string, string>,
+  );
+
+  const results = await queryDuckDB(`
+    SELECT title, tags, file_path, date, authors
+    FROM vault
+    WHERE tags IS NOT NULL
+    ORDER BY date DESC
+  `);
+
+  const filteredResults = results.filter(
+    result => result.title && Array.isArray(result.tags),
+  );
+
+  return Promise.all(
+    filteredResults.map(async result => {
+      const authorAvatars =
+        result.authors && Array.isArray(result.authors)
+          ? result.authors.map(author => avatarMap[author] ?? null)
+          : [];
+
+      return {
+        title: result.title as string,
+        tags: result.tags as string[],
+        filePath: result.file_path as string,
+        date: result.date as string,
+        authors: result.authors as string[],
+        authorAvatars,
+      };
+    }),
+  );
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -9,7 +9,7 @@ import path from 'path';
 import RemoteMdxRenderer from '@/components/RemoteMdxRenderer';
 import { SerializeResult } from 'next-mdx-remote-client';
 import { queryDuckDB } from '@/lib/db/utils';
-import { getCompactContributorsFromContentJSON } from '@/lib/contributor';
+import { MemosWithTagsProvider } from '@/contexts/memos-with-tags';
 
 interface HomePageProps extends RootLayoutPageProps {
   mdxSource?: SerializeResult;
@@ -96,53 +96,6 @@ export const getStaticProps: GetStaticProps = async () => {
       console.error('Error fetching hiring memos:', error);
     }
 
-    // get all memos with tags (object with title and tags field)
-    let memosWithTags: { title: string; tags: string[] }[] = [];
-    let avatarMap: Record<string, string | null> = {};
-    try {
-      const userProfiles = await getCompactContributorsFromContentJSON();
-      avatarMap = userProfiles.reduce(
-        (acc, profile) => {
-          if (profile.avatar) {
-            acc[profile.username] = profile.avatar;
-          }
-          return acc;
-        },
-        {} as Record<string, string>,
-      );
-
-      memosWithTags = await queryDuckDB(`
-        SELECT title, tags, file_path, date, authors
-        FROM vault
-        WHERE tags IS NOT NULL
-        ORDER BY date DESC
-      `).then(async results => {
-        const filteredResults = results.filter(
-          result => result.title && Array.isArray(result.tags),
-        );
-
-        return await Promise.all(
-          filteredResults.map(async result => {
-            const authorAvatars =
-              result.authors && Array.isArray(result.authors)
-                ? result.authors.map(author => avatarMap[author] ?? null)
-                : [];
-
-            return {
-              title: result.title as string,
-              tags: result.tags as string[],
-              filePath: result.file_path as string,
-              date: result.date as string,
-              authors: result.authors as string[],
-              authorAvatars,
-            };
-          }),
-        );
-      });
-    } catch (error) {
-      console.error('Error fetching memos with tags:', error);
-    }
-
     const mdxPath = path.join(process.cwd(), 'public/content/', `index.mdx`);
     const mdxSource = await getMdxSource({
       mdxPath,
@@ -152,10 +105,11 @@ export const getStaticProps: GetStaticProps = async () => {
         teamMemos,
         changelogMemos,
         hiringMemos,
-        // The vault's index.mdx still references this identifier when it renders
-        // <TagsMarquee />, which now reads the tree from context instead.
+        // The vault's index.mdx still references these identifiers when it
+        // renders <TagsMarquee />, <WorthReading /> and <MemoFilterList />,
+        // which now read the tree / memo list from context instead.
         directoryTree: {},
-        memosWithTags,
+        memosWithTags: [],
       },
     });
 
@@ -189,7 +143,9 @@ export default function Home({ searchIndex, mdxSource }: HomePageProps) {
       description="Knowledge sharing platform for Dwarves Foundation"
       searchIndex={searchIndex}
     >
-      <RemoteMdxRenderer mdxSource={mdxSource} />
+      <MemosWithTagsProvider>
+        <RemoteMdxRenderer mdxSource={mdxSource} />
+      </MemosWithTagsProvider>
     </RootLayout>
   );
 }


### PR DESCRIPTION
## Summary

Same class of bug that #336 fixed for `directoryTree`, applied to the homepage's `mdxSource.scope.memosWithTags`.

- The tagged-memo list (feeds `WorthReading` and `MemoFilterList` on the homepage only) was byte-identical on every visit but inlined into `__NEXT_DATA__` and the homepage's `_next/data` twin.
- It is now emitted once to `public/content/memos-with-tags.json` (alongside `directory-tree.json`) by `scripts/generate-memos-with-tags.ts`, and fetched client-side through a new `MemosWithTagsProvider` scoped to the homepage (not app-wide, since only the homepage consumes it), cache-busted the same way as the directory tree (`?v=<buildId>`).
- Unlike the directory tree, this field was **not** double-injected: it lives once in `mdxSource.scope` and is referenced twice within the rendered MDX (`WorthReading` and `MemoFilterList`), which does not duplicate it in the serialized payload.

## Measured (full static export, `make build-static`, before vs after)

| | Before | After | Delta |
|---|---|---|---|
| `out/index.html` | 498.1 KB | 248.0 KB | -50.2% |
| homepage `_next/data` twin | 253.5 KB | 15.5 KB | -93.9% |
| new static asset `memos-with-tags.json` | - | 238.0 KB (served once) | - |

Homepage-only impact (unlike the directory tree, which touched all 1152 pages), so total `out/` size drops by ~236 KB.

## Verified

- `npx tsc --noEmit`: clean except the pre-existing `aliases.json` module error.
- `pnpm exec vitest run`: 13 files / 132 tests pass.
- Full `make build-static` on both `main` (baseline) and this branch, served locally, loaded in a real browser:
  - `WorthReading` (20 links / 4 tag blocks) and `MemoFilterList` ("Latest memos", 20 links / 10 memos) render identically before and after.
  - `TagsMarquee` (unrelated, sanity-checked) still populates.
  - Console errors identical on both builds: 7 pre-existing static-export prefetch 404s (unrelated) + 1 pre-existing hydration mismatch (`React error #418`, same one #336 called out) + 2 unrelated warnings (Plausible, WalletConnect). No new errors introduced.
  - Confirmed both `directory-tree.json` and `memos-with-tags.json` are fetched once each, cache-busted with the build id.

## No-JS tradeoff

A visitor with JavaScript disabled no longer sees the "Worth Reading" and "Latest memos" sections on the homepage. Everything else on the homepage, and every other page, is unaffected.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `pnpm exec vitest run`
- [x] `make build-static` on main and this branch, diffed
- [x] Served both builds locally, browser-verified render + console parity
